### PR TITLE
ci: multi-agent safety — branch guard, claim ledger, lockfile merge drivers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,13 @@
 *.sh text eol=lf
 Dockerfile text eol=lf
 
+# Generated/lock files — on rebase conflicts, keep ours then regen.
+# The self-heal workflow regenerates these after any rebase automatically.
+# Never hand-resolve these; let the tooling do it.
+composer.lock merge=ours
+package-lock.json merge=ours
+phpstan-baseline.neon merge=ours
+
 # Binary files — no CRLF conversion
 *.png binary
 *.jpg binary

--- a/.github/agent-claims.json
+++ b/.github/agent-claims.json
@@ -1,0 +1,13 @@
+{
+  "claims": [],
+  "_schema": {
+    "description": "Agent work-claim ledger. Managed by scripts/agent-claim.py. TTL: 4h.",
+    "claim_fields": {
+      "agent": "Agent identifier (e.g. 'claude-sonnet-4-6', 'coderabbit-autofix')",
+      "branch": "The agent's PR branch name",
+      "patterns": "Array of glob patterns for claimed files (e.g. ['src/Controllers/**'])",
+      "claimed_at": "ISO 8601 UTC timestamp",
+      "session_id": "Optional session identifier"
+    }
+  }
+}

--- a/.github/workflows/multi-agent-guard.yml
+++ b/.github/workflows/multi-agent-guard.yml
@@ -1,0 +1,154 @@
+name: Multi-agent guard
+
+# Enforces conventions for concurrent agent workflows:
+#   1. Branch naming: agent/<id>/<topic>, dependabot/*, main, or trunk branches.
+#      PRs from non-conforming branches get a comment but are NOT blocked —
+#      the convention is advisory so human devs aren't locked out.
+#   2. Claim advisory: if .github/agent-claims.json shows another agent has
+#      claimed the files touched by this PR, posts a coordination comment.
+#      Non-blocking — advisory only.
+#   3. Push-to-main guard: direct pushes to main (not via PR merge) are
+#      rejected with an error.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  guard:
+    name: Multi-agent guard
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          sparse-checkout: .github/agent-claims.json
+          sparse-checkout-cone-mode: false
+
+      - name: Direct push to main guard
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          # Detect if this push came from a PR merge (has 2 parents) or is direct
+          PARENTS=$(git log -1 --format="%P" "${{ github.sha }}" | wc -w | tr -d ' ')
+          if [ "$PARENTS" -lt 2 ] && [[ "${{ github.event.head_commit.message }}" != *"Merge pull request"* ]]; then
+            echo "::error::Direct push to main detected. All changes must go through PRs."
+            echo "::error::Commit: ${{ github.sha }} | Message: $(git log -1 --format='%s' ${{ github.sha }})"
+            exit 1
+          fi
+          echo "Push to main is a merge commit — OK"
+
+      - name: Branch naming convention
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          echo "Checking branch: $BRANCH"
+
+          # Allowed patterns
+          if echo "$BRANCH" | grep -qE '^(agent/|dependabot/|fix/|feat/|chore/|docs/|refactor/|test/|security-|hotfix/)'; then
+            echo "Branch naming: OK ($BRANCH)"
+          else
+            echo "::warning::Branch '$BRANCH' doesn't follow naming convention."
+            echo "::warning::Expected: agent/<id>/<topic>, feat/<topic>, fix/<topic>, chore/<topic>, etc."
+            # Advisory only — post comment but don't fail
+            gh pr comment ${{ github.event.pull_request.number }} \
+              --body "⚠️ Branch name \`$BRANCH\` doesn't follow the convention (\`agent/<id>/<topic>\` or \`feat/\`, \`fix/\`, \`chore/\`, etc.). This is advisory only — CI will still run." \
+              --repo ${{ github.repository }} 2>/dev/null || true
+          fi
+
+      - name: Agent claim advisory
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Skip if agent-claims.json doesn't exist
+          if [ ! -f ".github/agent-claims.json" ]; then
+            echo "No agent-claims.json — skip claim check"
+            exit 0
+          fi
+
+          # Get the files changed in this PR
+          CHANGED_FILES=$(gh api repos/$REPO/pulls/${{ github.event.pull_request.number }}/files \
+            --jq '[.[] | .filename]' 2>/dev/null || echo "[]")
+
+          if [ "$CHANGED_FILES" = "[]" ]; then
+            echo "No changed files to check"
+            exit 0
+          fi
+
+          # Check claims file for conflicts
+          python3 - <<'PYEOF'
+          import json, sys, os
+          from datetime import datetime, timedelta, timezone
+          from pathlib import Path
+
+          claims_path = Path(".github/agent-claims.json")
+          try:
+              claims = json.loads(claims_path.read_text())
+          except Exception:
+              sys.exit(0)
+
+          changed_raw = os.environ.get("CHANGED_FILES_JSON", "[]")
+          try:
+              changed = json.loads(os.popen(f"echo '{changed_raw}'").read().strip())
+          except Exception:
+              sys.exit(0)
+
+          pr_branch = os.environ.get("PR_BRANCH", "")
+          now = datetime.now(timezone.utc)
+          cutoff = now - timedelta(hours=4)
+
+          conflicts = []
+          for claim in claims.get("claims", []):
+              # Skip expired claims
+              try:
+                  claimed_at = datetime.fromisoformat(claim["claimed_at"].replace("Z", "+00:00"))
+                  if claimed_at < cutoff:
+                      continue
+              except Exception:
+                  continue
+
+              # Skip if same agent's branch
+              if claim.get("branch") == pr_branch:
+                  continue
+
+              # Check if any changed file matches the claim's glob
+              import fnmatch
+              for f in changed:
+                  for pattern in claim.get("patterns", []):
+                      if fnmatch.fnmatch(f, pattern):
+                          conflicts.append({
+                              "agent": claim.get("agent", "unknown"),
+                              "branch": claim.get("branch", "unknown"),
+                              "file": f,
+                              "pattern": pattern,
+                          })
+                          break
+
+          if conflicts:
+              print("::warning::Agent claim conflicts detected:")
+              for c in conflicts:
+                  print(f"::warning::  {c['agent']} ({c['branch']}) has claimed '{c['pattern']}' covering {c['file']}")
+              sys.exit(2)  # Use exit code 2 to signal advisory (caught below)
+          PYEOF
+
+          EXIT_CODE=$?
+          if [ "$EXIT_CODE" -eq 2 ]; then
+            # Post advisory comment but don't fail the job
+            gh pr comment ${{ github.event.pull_request.number }} \
+              --body "⚠️ Agent claim overlap detected. Another agent has claimed files touched by this PR. This is **advisory only** — coordinate if editing the same code paths." \
+              --repo $REPO 2>/dev/null || true
+          fi
+          exit 0   # Always exit 0 — advisory only
+        env:
+          CHANGED_FILES_JSON: ${{ toJson(github.event.pull_request.changed_files) }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/pr-closed-handoff.yml
+++ b/.github/workflows/pr-closed-handoff.yml
@@ -1,0 +1,118 @@
+name: PR closed — agent hand-off
+
+# When a PR is closed (merged or abandoned):
+# 1. Extract agent context (key decisions, learnings) and append to
+#    docs/agent-handoffs/<pr-number>.md so the next agent can pick up
+#    context without re-deriving.
+# 2. Release any agent claims from .github/agent-claims.json.
+#
+# This keeps the multi-agent work-claim ledger clean and ensures
+# architectural decisions survive across PR boundaries.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  handoff:
+    name: Agent hand-off for PR #${{ github.event.pull_request.number }}
+    runs-on: ubuntu-latest
+    # Skip Dependabot PRs — they don't carry agent context
+    if: "!startsWith(github.event.pull_request.user.login, 'dependabot')"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "stratflow-ci[bot]"
+          git config user.email "stratflow-ci[bot]@users.noreply.github.com"
+
+      - name: Extract and save agent context
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          MERGED: ${{ github.event.pull_request.merged }}
+          MERGE_COMMIT: ${{ github.event.pull_request.merge_commit_sha }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          # Extract agent observations from commit trailers and PR body
+          HANDOFF_DIR="docs/agent-handoffs"
+          mkdir -p "$HANDOFF_DIR"
+          HANDOFF_FILE="$HANDOFF_DIR/$PR_NUMBER.md"
+
+          # Collect commit messages from this PR
+          BASE_SHA=$(gh api repos/$REPO/pulls/$PR_NUMBER \
+            --jq '.base.sha' 2>/dev/null || echo "")
+          HEAD_SHA="${MERGE_COMMIT:-${{ github.event.pull_request.head.sha }}}"
+
+          COMMITS=""
+          if [ -n "$BASE_SHA" ]; then
+            COMMITS=$(git log --oneline "${BASE_SHA}..${HEAD_SHA}" 2>/dev/null || echo "")
+          fi
+
+          STATUS=$([ "$MERGED" = "true" ] && echo "merged" || echo "closed without merge")
+
+          cat > "$HANDOFF_FILE" <<MARKDOWN
+# PR #$PR_NUMBER: $PR_TITLE
+
+**Status:** $STATUS
+**Branch:** $BRANCH
+**Author:** $AUTHOR
+**Date:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
+$([ -n "$MERGE_COMMIT" ] && echo "**Merge commit:** \`${MERGE_COMMIT:0:8}\`" || echo "")
+
+## Description
+
+$PR_BODY
+
+## Commits
+
+\`\`\`
+$COMMITS
+\`\`\`
+
+## Key decisions (auto-extracted from commit trailers)
+
+$(git log --format='%B' "${BASE_SHA}..${HEAD_SHA}" 2>/dev/null | \
+  grep -E '^(Decision|Rationale|Trade-off|Note|Observation):' | \
+  sed 's/^/- /' || echo "_None recorded in commit trailers._")
+
+## Reviewers
+
+$(gh api repos/$REPO/pulls/$PR_NUMBER/reviews \
+  --jq '[.[] | select(.state == "APPROVED") | "- \(.user.login) approved"] | join("\n")' \
+  2>/dev/null || echo "_Review data unavailable._")
+MARKDOWN
+
+          echo "Handoff written to $HANDOFF_FILE"
+
+      - name: Release agent claims
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if [ -f ".github/agent-claims.json" ] && [ -f "scripts/agent-claim.py" ]; then
+            python3 scripts/agent-claim.py release --branch "$BRANCH" && \
+              echo "Released claims for $BRANCH" || echo "No claims to release"
+          fi
+
+      - name: Commit handoff and claim release
+        run: |
+          git add docs/agent-handoffs/ .github/agent-claims.json 2>/dev/null || true
+          if git diff --cached --quiet; then
+            echo "Nothing to commit"
+          else
+            git commit -m "chore: agent hand-off for PR #${{ github.event.pull_request.number }} [ci skip]"
+            git push origin HEAD:main
+          fi

--- a/docs/agent-handoffs/.gitkeep
+++ b/docs/agent-handoffs/.gitkeep
@@ -1,0 +1,1 @@
+# Agent Hand-offs

--- a/scripts/agent-claim.py
+++ b/scripts/agent-claim.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+agent-claim.py — Agent work-claim ledger for concurrent agent safety.
+
+Manages .github/agent-claims.json to track which agent owns which files.
+Advisory-only: another agent touching claimed files gets a warning, not a block.
+
+Usage:
+  python3 scripts/agent-claim.py claim --agent "claude-sonnet-4-6" \\
+      --branch "agent/abc/feature" --patterns "src/Controllers/**" "src/Models/Foo.php"
+
+  python3 scripts/agent-claim.py release --branch "agent/abc/feature"
+
+  python3 scripts/agent-claim.py list
+
+  python3 scripts/agent-claim.py prune   # Remove expired claims (>4h old)
+
+Typical CI usage:
+  # At PR open:
+  python3 scripts/agent-claim.py claim --agent "$AGENT_ID" --branch "$PR_BRANCH" \
+    --patterns $(git diff --name-only origin/main...HEAD | tr '\n' ' ')
+
+  # At PR close:
+  python3 scripts/agent-claim.py release --branch "$PR_BRANCH"
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+CLAIMS_PATH = Path(".github/agent-claims.json")
+TTL_HOURS = 4
+
+
+def load_claims() -> dict:
+    if CLAIMS_PATH.exists():
+        try:
+            return json.loads(CLAIMS_PATH.read_text(encoding="utf-8"))
+        except Exception:
+            pass
+    return {"claims": []}
+
+
+def save_claims(data: dict) -> None:
+    CLAIMS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    CLAIMS_PATH.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8"
+    )
+
+
+def prune_expired(claims: list[dict]) -> list[dict]:
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=TTL_HOURS)
+    active = []
+    for c in claims:
+        try:
+            ts = datetime.fromisoformat(c["claimed_at"].replace("Z", "+00:00"))
+            if ts >= cutoff:
+                active.append(c)
+        except Exception:
+            pass  # Drop malformed entries
+    return active
+
+
+def cmd_claim(args: argparse.Namespace) -> int:
+    data = load_claims()
+    claims = prune_expired(data.get("claims", []))
+
+    # Remove any existing claim for this branch
+    claims = [c for c in claims if c.get("branch") != args.branch]
+
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    claim = {
+        "agent": args.agent,
+        "branch": args.branch,
+        "patterns": args.patterns,
+        "claimed_at": now,
+    }
+    if args.session_id:
+        claim["session_id"] = args.session_id
+
+    claims.append(claim)
+    data["claims"] = claims
+    save_claims(data)
+    print(f"Claimed {len(args.patterns)} pattern(s) for {args.agent} on {args.branch}")
+    return 0
+
+
+def cmd_release(args: argparse.Namespace) -> int:
+    data = load_claims()
+    before = len(data.get("claims", []))
+    data["claims"] = [c for c in data.get("claims", []) if c.get("branch") != args.branch]
+    released = before - len(data["claims"])
+    save_claims(data)
+    print(f"Released {released} claim(s) for branch {args.branch}")
+    return 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    data = load_claims()
+    claims = prune_expired(data.get("claims", []))
+    if not claims:
+        print("No active claims")
+        return 0
+    now = datetime.now(timezone.utc)
+    for c in claims:
+        try:
+            ts = datetime.fromisoformat(c["claimed_at"].replace("Z", "+00:00"))
+            age_min = int((now - ts).total_seconds() / 60)
+        except Exception:
+            age_min = -1
+        patterns = ", ".join(c.get("patterns", []))
+        print(f"  [{age_min}m ago] {c['agent']} ({c['branch']}): {patterns}")
+    return 0
+
+
+def cmd_prune(args: argparse.Namespace) -> int:
+    data = load_claims()
+    before = len(data.get("claims", []))
+    data["claims"] = prune_expired(data.get("claims", []))
+    removed = before - len(data["claims"])
+    save_claims(data)
+    print(f"Pruned {removed} expired claim(s). {len(data['claims'])} active.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Agent work-claim ledger")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    claim_p = subparsers.add_parser("claim", help="Claim file patterns for an agent")
+    claim_p.add_argument("--agent", required=True, help="Agent identifier")
+    claim_p.add_argument("--branch", required=True, help="PR branch name")
+    claim_p.add_argument("--patterns", nargs="+", required=True, help="File glob patterns")
+    claim_p.add_argument("--session-id", default="", help="Optional session identifier")
+
+    release_p = subparsers.add_parser("release", help="Release claims for a branch")
+    release_p.add_argument("--branch", required=True, help="PR branch name to release")
+
+    subparsers.add_parser("list", help="List active claims")
+    subparsers.add_parser("prune", help="Remove expired claims")
+
+    args = parser.parse_args()
+
+    if args.command == "claim":
+        return cmd_claim(args)
+    elif args.command == "release":
+        return cmd_release(args)
+    elif args.command == "list":
+        return cmd_list(args)
+    elif args.command == "prune":
+        return cmd_prune(args)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

PR 2 of the [CI Resilience plan](https://github.com/semajyad/stratflow/blob/main/.claude/plans/velvet-sprouting-bumblebee.md). Concurrent agents working on the same repo need explicit contention management so they don't step on each other or create merge conflicts on generated files.

### multi-agent-guard.yml (new)
- **Branch naming**: enforces `agent/<id>/<topic>`, `feat/`, `fix/`, `chore/`, etc. Advisory (comment, not block) — human devs aren't locked out.
- **Claim advisory**: if `.github/agent-claims.json` shows another agent has claimed files touched by this PR, posts a coordination comment. Non-blocking.
- **Direct push guard**: rejects any commit pushed directly to `main` that isn't a merge commit. All code must go through PRs.

### .github/agent-claims.json + scripts/agent-claim.py
- TTL-based (4h) work-claim ledger for concurrent agents.
- `claim --agent X --branch Y --patterns 'src/Controllers/**'` — register ownership
- `release --branch Y` — release when PR closes (done automatically by hand-off workflow)
- `list` / `prune` — inspection and cleanup

### .gitattributes — lockfile merge drivers
- `composer.lock`, `package-lock.json`, `phpstan-baseline.neon` all get `merge=ours`
- When two agents rebase concurrently and both touch these files, git auto-keeps ours version
- The `self-heal` workflow (PR 1) then regenerates correct content after the rebase
- Zero hand-resolution of generated file conflicts

### pr-closed-handoff.yml (new)
- On every PR close: extracts agent decisions from commit trailers, writes to `docs/agent-handoffs/<pr>.md`
- Releases the agent's claims from the ledger
- Commits the handoff doc with `[ci skip]` to avoid triggering more CI

## Test plan
- [ ] Push directly to `main` → guard rejects with error.
- [ ] Open a PR from `random-branch` → advisory comment posted, CI proceeds.
- [ ] Run `python3 scripts/agent-claim.py claim --agent test --branch feat/x --patterns "src/Controllers/**"` then open a PR touching `src/Controllers/` → advisory comment posted.
- [ ] Merge two PRs that both modify `composer.lock` → merge driver resolves conflict, self-heal regenerates correct lockfile.
- [ ] Close a PR → `docs/agent-handoffs/<number>.md` created, claims released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-agent coordination system to detect and warn about overlapping work on pull requests
  * Automated PR handoff documentation generation with commit summaries and reviewer information
  * Implemented branch naming validation with advisory checks for pull requests

* **Chores**
  * Configured merge strategies for lock and generated configuration files
  * Established agent work-claim tracking infrastructure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->