### PR TITLE
fix: dependency-review is advisory (requires GHAS not available)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -24,8 +24,11 @@ jobs:
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v4
+        # GitHub Advanced Security (GHAS) is required on private repos.
+        # Without it the action fails with "not supported on this repository".
+        # composer audit in tests.yml already covers CVEs at the tool level.
+        # Advisory only — visible but not blocking.
+        continue-on-error: true
         with:
-          # Block PRs introducing HIGH or CRITICAL CVEs
           fail-on-severity: high
-          # Post a summary comment on the PR listing new dependencies
           comment-summary-in-pr: always


### PR DESCRIPTION
The `actions/dependency-review-action` requires GitHub Advanced Security which isn't available on this private repo without a GHAS license. It has been failing on every PR since it was added.

**Fix:** `continue-on-error: true` — the check runs, results are visible, but it doesn't block merge.

**Coverage:** `composer audit` already runs in the `unit` job in `tests.yml` and covers dependency CVEs. Nightly Snyk scan covers the same ground in depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to no longer block pull requests on dependency review failures, while still checking dependencies and posting review summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->