### PR TITLE
chore: add Security notes to PR template + advisory CI enforcement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,20 @@
 
 <!-- Why is this change needed? Link to issue if applicable. -->
 
+## Security notes
+
+<!--
+Required if this PR touches: auth, sessions, permissions, billing, webhooks,
+file uploads, external APIs, HTTP headers, middleware, or any new stored data.
+Delete this section only for pure refactors, tests, docs, or config changes.
+
+Answer whichever of these apply:
+- What data does this touch, and who should be able to access it?
+- What is the worst-case abuse of this feature by a malicious user or outsider?
+- What existing controls cover it (CSRF, auth middleware, prepared statements,
+  output escaping, rate limiting) and is anything left unguarded?
+-->
+
 ## Test plan
 
 <!-- How was this tested? CI covers the basics — note anything manual. -->
@@ -15,3 +29,4 @@
 - [ ] CI passes (Tests + E2E fast required; full suite runs post-merge)
 - [ ] No secrets, hardcoded credentials, or debug statements
 - [ ] New `src/**/*.php` files have a matching test, or PR has `no-test-required` label
+- [ ] Security notes filled in, or section deleted for non-security changes

--- a/.github/workflows/security-notes-check.yml
+++ b/.github/workflows/security-notes-check.yml
@@ -29,10 +29,10 @@ jobs:
           fetch-depth: 0
 
       - name: Write PR body to file
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          cat > /tmp/pr_body.txt << 'PREOF'
-          ${{ github.event.pull_request.body }}
-          PREOF
+          printf '%s' "$PR_BODY" > /tmp/pr_body.txt
 
       - name: Check security notes
         run: |

--- a/.github/workflows/security-notes-check.yml
+++ b/.github/workflows/security-notes-check.yml
@@ -1,0 +1,46 @@
+name: Security notes check
+
+# Advisory-only check. Posts a PR comment when security-sensitive files
+# are changed but the PR description has no Security notes section.
+# Never blocks merge — exit 0 always.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write  # to post advisory comment
+
+concurrency:
+  group: security-notes-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Security notes advisory
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Write PR body to file
+        run: |
+          cat > /tmp/pr_body.txt << 'PREOF'
+          ${{ github.event.pull_request.body }}
+          PREOF
+
+      - name: Check security notes
+        run: |
+          python3 scripts/ci/check_security_notes.py \
+            --base origin/${{ github.base_ref }} \
+            --head HEAD \
+            --pr-body-file /tmp/pr_body.txt
+        env:
+          GH_PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,19 @@ If the task touches auth, permissions, sessions, secrets, uploads, billing, webh
 - If the same fix attempt fails 3 times, stop and rescope instead of thrashing.
 - Before finishing, prefer the simpler solution if it reduces code and context size safely.
 
+## Security Notes — MANDATORY on security-touching PRs
+
+When opening a PR that touches auth, sessions, permissions, billing, webhooks,
+file uploads, external APIs, HTTP headers, middleware, controllers, or any new
+stored data: **fill in the `## Security notes` section** of the PR description.
+
+Answer whichever of these apply (3–5 bullet points, not an essay):
+- What data does this touch, and who should be able to access it?
+- What is the worst-case abuse by a malicious user or outsider?
+- What existing controls cover it, and is anything left unguarded?
+
+For pure refactors, tests, docs, or config-only changes: delete the section.
+
 ## Unit Test Rule — MANDATORY
 
 **Every new or modified `src/**/*.php` file must have a unit test written before the task is considered complete.**

--- a/scripts/ci/check_security_notes.py
+++ b/scripts/ci/check_security_notes.py
@@ -20,7 +20,7 @@ import sys
 
 # Paths that warrant a security note when changed
 SECURITY_SENSITIVE = [
-    r"^src/Controllers/Auth",
+    r"^src/Controllers/",   # all controllers touch auth/data boundaries
     r"^src/Middleware/",
     r"^src/Security/",
     r"^src/Services/Auth",

--- a/scripts/ci/check_security_notes.py
+++ b/scripts/ci/check_security_notes.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+check_security_notes.py — warn when security-sensitive files are changed
+but the PR description has no Security notes section.
+
+Exit 0 always (advisory only — never blocks merge).
+Posts a GitHub PR comment if the section is missing.
+
+Usage:
+    python3 scripts/ci/check_security_notes.py \
+        --base origin/main --head HEAD \
+        --pr-body-file /tmp/pr_body.txt
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+# Paths that warrant a security note when changed
+SECURITY_SENSITIVE = [
+    r"^src/Controllers/Auth",
+    r"^src/Middleware/",
+    r"^src/Security/",
+    r"^src/Services/Auth",
+    r"^src/Services/Billing",
+    r"^src/Services/Payment",
+    r"^src/Services/Webhook",
+    r"^src/Services/Upload",
+    r"^src/Services/Email",
+    r"^src/Config/routes\.php",
+    r"^database/migrations/",
+    r"^database/schema\.sql",
+    r"^public/index\.php",
+]
+
+SECTION_HEADER = "## Security notes"
+
+# If the section body still looks like the untouched template placeholder, treat as missing
+PLACEHOLDER_PATTERN = re.compile(
+    r"<!--.*?-->",
+    re.DOTALL,
+)
+
+
+def get_changed_files(base: str, head: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "diff", "--name-only", f"{base}...{head}"],
+        capture_output=True, text=True,
+    )
+    return [l.strip() for l in result.stdout.splitlines() if l.strip()]
+
+
+def is_security_sensitive(path: str) -> bool:
+    return any(re.match(pattern, path) for pattern in SECURITY_SENSITIVE)
+
+
+def has_security_notes(body: str) -> bool:
+    if SECTION_HEADER not in body:
+        return False
+    # Find the section content after the header
+    idx = body.index(SECTION_HEADER) + len(SECTION_HEADER)
+    # Get text until the next ## heading or end of string
+    rest = body[idx:]
+    next_heading = re.search(r"^##\s", rest, re.MULTILINE)
+    section_body = rest[:next_heading.start()] if next_heading else rest
+    # Strip HTML comments (template placeholders)
+    stripped = PLACEHOLDER_PATTERN.sub("", section_body).strip()
+    # Require at least 20 chars of real content
+    return len(stripped) >= 20
+
+
+def post_pr_comment(message: str) -> None:
+    pr_number = os.environ.get("GH_PR_NUMBER") or os.environ.get("PR_NUMBER")
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not all([pr_number, repo, token]):
+        print(f"  (cannot post comment — missing GH_PR_NUMBER/GITHUB_REPOSITORY/GH_TOKEN)")
+        return
+    subprocess.run(
+        ["gh", "pr", "comment", pr_number, "--body", message, "--repo", repo],
+        env={**os.environ, "GH_TOKEN": token},
+        capture_output=True,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", default="origin/main")
+    parser.add_argument("--head", default="HEAD")
+    parser.add_argument("--pr-body-file", default="")
+    args = parser.parse_args()
+
+    # Read PR body
+    body = ""
+    if args.pr_body_file and os.path.isfile(args.pr_body_file):
+        body = open(args.pr_body_file).read()
+    elif os.environ.get("PR_BODY"):
+        body = os.environ["PR_BODY"]
+
+    # Get changed files
+    changed = get_changed_files(args.base, args.head)
+    sensitive = [f for f in changed if is_security_sensitive(f)]
+
+    if not sensitive:
+        print("check_security_notes: no security-sensitive files changed — skip")
+        return 0
+
+    print(f"check_security_notes: {len(sensitive)} security-sensitive file(s) changed:")
+    for f in sensitive:
+        print(f"  {f}")
+
+    if not body:
+        print("  WARNING: no PR body available to check — cannot verify security notes")
+        return 0
+
+    if has_security_notes(body):
+        print("  ✓ Security notes section present and filled in")
+        return 0
+
+    # Missing — warn via output and PR comment
+    files_list = "\n".join(f"  - `{f}`" for f in sensitive)
+    message = (
+        "## ⚠️ Security notes missing\n\n"
+        "This PR changes security-sensitive files but the **Security notes** section "
+        "in the PR description appears empty or contains only the template placeholder.\n\n"
+        f"**Changed files that triggered this:**\n{files_list}\n\n"
+        "Please fill in the security notes (3–5 bullets):\n"
+        "- What data does this touch, and who should be able to access it?\n"
+        "- What is the worst-case abuse by a malicious user or outsider?\n"
+        "- What existing controls cover it, and is anything left unguarded?\n\n"
+        "_This is advisory — it will not block your PR from merging._"
+    )
+    print(f"\n::warning::{message.splitlines()[2]}")
+    post_pr_comment(message)
+    # Exit 0 — advisory only, never blocks merge
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check_security_notes.py
+++ b/scripts/ci/check_security_notes.py
@@ -49,6 +49,9 @@ def get_changed_files(base: str, head: str) -> list[str]:
         ["git", "diff", "--name-only", f"{base}...{head}"],
         capture_output=True, text=True,
     )
+    if result.returncode != 0:
+        print(f"check_security_notes: git diff failed: {result.stderr.strip()}", file=sys.stderr)
+        return []
     return [l.strip() for l in result.stdout.splitlines() if l.strip()]
 
 
@@ -95,7 +98,8 @@ def main() -> int:
     # Read PR body
     body = ""
     if args.pr_body_file and os.path.isfile(args.pr_body_file):
-        body = open(args.pr_body_file).read()
+        with open(args.pr_body_file) as fh:
+            body = fh.read()
     elif os.environ.get("PR_BODY"):
         body = os.environ["PR_BODY"]
 


### PR DESCRIPTION
## What
Adds a lightweight threat-modelling habit to every PR via a structured Security notes section.

## Why
Formal threat modelling (OWASP Threat Dragon) is overkill for a fast-moving solo startup. This captures 80% of the value in a few bullet points per PR.

## Security notes
_No security-sensitive files changed — CI/infrastructure only._

## Test plan
- [ ] Open a new PR touching `src/Controllers/AuthController.php` — advisory comment should appear
- [ ] Open a PR touching only `tests/` — no comment, check passes silently

## Checklist
- [x] CI passes
- [x] No secrets or debug statements
- [x] Security notes filled in (n/a — deleted, config change only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an advisory security-notes check for PRs to main that detects security-sensitive changes and posts guidance/comments if the required security notes are missing; advisory-only and does not block merges.

* **Documentation**
  * Updated the PR template and contributor guidelines with a mandatory "Security notes" section for security-touching changes, specifying required questions to answer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->