### PR TITLE
fix: Logger STDOUT namespace error (500 on login/logout) + public logo size

### DIFF
--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -6527,7 +6527,7 @@ details[open] > summary .trace-chevron {
 }
 
 .public-header .logo img {
-    height: 32px;
+    height: 72px;
     width: auto;
     display: block;
 }

--- a/src/Services/Logger.php
+++ b/src/Services/Logger.php
@@ -142,7 +142,7 @@ class Logger
         }
 
         // Write to stdout — container platform captures this
-        $stream = self::$outputStream ?? STDOUT;
+        $stream = self::$outputStream ?? \STDOUT;
         fwrite($stream, json_encode($entry, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) . PHP_EOL);
     }
 }


### PR DESCRIPTION
## Summary

- **500 on /login and /logout**: `Logger.php` referenced `STDOUT` without a leading `\` inside the `StratFlow\Services` namespace. PHP resolved it as `StratFlow\Services\STDOUT` (undefined constant), causing a fatal double-fault whenever any unhandled exception hit the error handler. The error handler called `Logger::error()`, which itself threw, producing a blank 500 with no useful log output.
- **Logo size**: public header logo was `height: 32px` — same size as a favicon. Raised to `72px` to match the sidebar brand logo visible when logged in.

## Root cause detail

```
PHP Fatal error: Uncaught Error: Undefined constant "StratFlow\Services\STDOUT"
  in /app/src/Services/Logger.php:145
```

Fix: `STDOUT` → `\STDOUT` (global namespace escape).

## Test plan
- [ ] Visit /logout — no 500, redirects to /login cleanly
- [ ] Visit /login with bad credentials — error shown, no 500
- [ ] Pricing page logo matches size of sidebar logo when logged in

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logger reliability by ensuring correct constant reference in fallback logging output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->