### PR TITLE
fix: Logger php://stdout (STDOUT unavailable in web SAPI) + Session PHP 8.4

### DIFF
--- a/src/Core/Session.php
+++ b/src/Core/Session.php
@@ -44,8 +44,13 @@ class Session
             ini_set('session.use_only_cookies', '1');
             ini_set('session.cookie_httponly', '1');
             ini_set('session.cookie_samesite', 'Lax');
-            ini_set('session.sid_length', '48');
-            ini_set('session.sid_bits_per_character', '6');
+            // session.sid_length and session.sid_bits_per_character were
+            // deprecated in PHP 8.4 — the equivalent is now set via
+            // session_set_cookie_params or left at PHP defaults (128-bit).
+            if (PHP_VERSION_ID < 80400) {
+                ini_set('session.sid_length', '48');
+                ini_set('session.sid_bits_per_character', '6');
+            }
 
             session_set_cookie_params([
                 'lifetime' => 0,           // Browser session only

--- a/src/Services/Logger.php
+++ b/src/Services/Logger.php
@@ -141,8 +141,19 @@ class Logger
             $entry['ctx'] = $ctx;
         }
 
-        // Write to stdout — container platform captures this
-        $stream = self::$outputStream ?? \STDOUT;
-        fwrite($stream, json_encode($entry, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) . PHP_EOL);
+        // Write to stdout — container platform captures this.
+        // STDOUT constant is unavailable in php-fpm and the built-in web
+        // server's forked request workers, so we open php://stdout which
+        // is always available regardless of SAPI.
+        static $stdoutHandle = null;
+        if ($stdoutHandle === null) {
+            $stdoutHandle = fopen('php://stdout', 'wb');
+        }
+        $stream = self::$outputStream ?? $stdoutHandle;
+        if ($stream !== false && $stream !== null) {
+            fwrite($stream, json_encode($entry, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) . PHP_EOL);
+        } else {
+            error_log(json_encode($entry, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        }
     }
 }


### PR DESCRIPTION
## Root cause

Login/logout 500s were caused by two bugs:

**1. Logger.php line 145 — `STDOUT` constant undefined in production**

PR #33 changed bare `STDOUT` to `\STDOUT` (global namespace lookup). That still fails because `STDOUT` is a predefined resource constant that PHP only registers in true CLI SAPI — it is NOT available in php-fpm or in the built-in web server's forked request workers (`php -S`). Railway uses `php -S`, so every Logger call died with `Undefined constant "STDOUT"`.

Because Logger died in the exception handler (`index.php:88`), the error handler never completed, the `error_log()` fallback on the next line never ran, and the real underlying exception was swallowed entirely — making the 500 very hard to diagnose.

**Fix:** Open `php://stdout` once via a static handle (always available regardless of SAPI). Fallback to `error_log()` if the handle fails.

**2. Session.php — E_DEPRECATED on every request (PHP 8.4)**

`session.sid_length` and `session.sid_bits_per_character` were deprecated in PHP 8.4. Every request emitted two deprecation notices, polluting the Railway log and potentially triggering strict error handlers. Guarded with `PHP_VERSION_ID < 80400`.

## Note

The real exception that was being thrown in the login handler is now unmasked and will appear in logs after this fix deploys. If there's a secondary issue it will be visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Session configuration now properly adapts to PHP 8.4+ requirements, ensuring consistent functionality across all supported PHP versions
- Logging system enhanced for improved reliability, ensuring logs are consistently captured and written across diverse PHP server environments and configurations, including setups where standard output streams may have limited availability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->