### PR TITLE
fix: migration runner closeCursor — fixes PDO 2014 / missing audit_logs columns

### DIFF
--- a/scripts/init-db.php
+++ b/scripts/init-db.php
@@ -51,7 +51,14 @@ try {
             foreach ($statements as $stmt) {
                 if ($stmt === '') continue;
                 try {
-                    $pdo->exec($stmt);
+                    // Use query() instead of exec() so we get a PDOStatement
+                    // whose cursor we can close. exec() leaves PREPARE/EXECUTE
+                    // result sets open, causing PDO 2014 errors on the next
+                    // statement in migrations that use dynamic SQL.
+                    $result = $pdo->query($stmt);
+                    if ($result instanceof PDOStatement) {
+                        $result->closeCursor();
+                    }
                 } catch (PDOException $e) {
                     // 1060 = Duplicate column, 1061 = Duplicate key, 1826 = Duplicate FK name — safe to skip
                     if (in_array($e->errorInfo[1] ?? 0, [1060, 1061, 1826])) {


### PR DESCRIPTION
## Problem

Migration 036 uses `PREPARE/EXECUTE` for conditional DDL. `PDO::exec()` doesn't consume the result set left open by `EXECUTE`, so every subsequent statement (and all following migration files) fails with:

```
SQLSTATE[HY000]: General error: 2014 Cannot execute queries while other unbuffered queries are active.
```

This silently broke migrations 036–040 on every deployment. The most visible symptom: `audit_logs` is missing `row_hash`, `prev_hash`, `org_id`, `resource_type`, `resource_id` columns (migration 038), causing AuditLogger to fall back to file logging on every login/logout.

## Fix

Replace `$pdo->exec($stmt)` with `$pdo->query($stmt)->closeCursor()`. This ensures each statement's result set is consumed before the next statement runs.

After this deploys, migrations 036–040 will complete cleanly. Statements already applied get a 1060/1061 duplicate-column skip (safe). The missing `audit_logs` columns will be added by migration 038 on the next container start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database initialization script to properly manage database cursors during migration execution, enhancing reliability of the database setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->