### PR TITLE
fix: MCP accordion click broken + style inconsistent with app

### DIFF
--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -5429,9 +5429,6 @@ select.kr-field--compact {
     border-color: var(--primary, #3b82f6);
 }
 
-.mcp-chevron--expanded {
-    transform: rotate(180deg);
-}
 
 .jira-sync-preview-card {
     margin: 0;
@@ -8457,36 +8454,18 @@ a.okr-title:hover {
     width: 220px;
 }
 
-.access-token-guide-toggle {
-    width: 100%;
+.mcp-guide-info {
+    flex: 1;
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    padding: 1rem 1.25rem;
-    background: none;
-    border: none;
-    cursor: pointer;
-    text-align: left;
+    gap: 0.5rem;
+    min-width: 0;
 }
 
-.access-token-guide-head {
-    display: flex;
-    align-items: center;
-    gap: 0.625rem;
-}
-
-.access-token-guide-label {
+.mcp-guide-name {
     font-weight: 600;
-    font-size: 0.9375rem;
-}
-
-.access-token-guide-chevron {
-    flex-shrink: 0;
-    transition: transform 0.2s;
-}
-
-.access-token-guide {
-    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+    white-space: nowrap;
 }
 
 .access-token-guide-body {
@@ -8553,14 +8532,19 @@ a.okr-title:hover {
     margin: 0;
 }
 
-.mcp-accordion-item + .mcp-accordion-item {
-    border-top: 1px solid var(--border);
+
+.mcp-guide-sublabel {
+    font-size: 0.78rem;
+    color: var(--text-muted, #6b7280);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
-.access-token-guide-sublabel {
-    font-size: .75rem;
-    color: var(--text-muted, #6b7280);
-    margin-left: .5rem;
+.mcp-guide-sublabel code {
+    font-size: 0.75rem;
+    background: none;
+    color: inherit;
 }
 
 .access-token-step-list {

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -272,13 +272,6 @@ document.addEventListener('click', function(e) {
         return;
     }
 
-    var mcpAccordionBtn = e.target.closest('.js-mcp-accordion');
-    if (mcpAccordionBtn) {
-        e.preventDefault();
-        toggleMcpAccordion(mcpAccordionBtn);
-        return;
-    }
-
     if (e.target.closest('.js-close-node-okr-panel')) {
         e.preventDefault();
         closeNodeOkrPanel();
@@ -2910,18 +2903,6 @@ function closeDiagramOkrModal() {
     var modal = document.getElementById('add-okr-modal');
     if (modal) {
         modal.classList.add('hidden');
-    }
-}
-
-function toggleMcpAccordion(btn) {
-    var targetId = btn.dataset.target;
-    if (!targetId) { return; }
-    var body = document.getElementById(targetId);
-    if (!body) { return; }
-    var isHidden = body.classList.toggle('hidden');
-    var chevron = btn.querySelector('.access-token-guide-chevron');
-    if (chevron) {
-        chevron.classList.toggle('mcp-chevron--expanded', !isHidden);
     }
 }
 

--- a/templates/account/access-tokens.php
+++ b/templates/account/access-tokens.php
@@ -399,29 +399,28 @@ $mcp_url = htmlspecialchars($app_url, ENT_QUOTES, 'UTF-8');
     ];
     ?>
 
-    <?php foreach ($mcp_accordions as $accordion): ?>
-    <div class="mcp-accordion-item">
-        <button type="button"
-                class="js-mcp-accordion access-token-guide-toggle"
-                data-target="mcp-guide-<?= htmlspecialchars($accordion['id'], ENT_QUOTES, 'UTF-8') ?>">
-            <div class="access-token-guide-head">
-                <?= $accordion['logo'] ?>
-                <span class="access-token-guide-label"><?= htmlspecialchars($accordion['label'], ENT_QUOTES, 'UTF-8') ?></span>
-                <span class="access-token-guide-sublabel"><?= $accordion['sublabel'] ?></span>
-            </div>
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"
-                 class="access-token-guide-chevron">
-                <polyline points="6 9 12 15 18 9"/>
-            </svg>
-        </button>
-        <div id="mcp-guide-<?= htmlspecialchars($accordion['id'], ENT_QUOTES, 'UTF-8') ?>"
-             class="access-token-guide hidden">
-            <div class="card-body access-token-guide-body">
+    <div class="card-body pt-0">
+        <div class="settings-stack">
+        <?php foreach ($mcp_accordions as $accordion): ?>
+        <div class="accordion-item">
+            <button type="button" class="accordion-header js-accordion-toggle">
+                <span class="mcp-guide-logo" aria-hidden="true"><?= $accordion['logo'] ?></span>
+                <span class="mcp-guide-info">
+                    <span class="mcp-guide-name"><?= htmlspecialchars($accordion['label'], ENT_QUOTES, 'UTF-8') ?></span>
+                    <span class="mcp-guide-sublabel"><?= $accordion['sublabel'] ?></span>
+                </span>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"
+                     class="accordion-chevron">
+                    <polyline points="6 9 12 15 18 9"/>
+                </svg>
+            </button>
+            <div class="accordion-body access-token-guide-body">
                 <?= $accordion['content'] ?>
             </div>
         </div>
+        <?php endforeach; ?>
+        </div>
     </div>
-    <?php endforeach; ?>
 
 </section>
 


### PR DESCRIPTION
## Summary

- **Accordion click broken**: `<div>` inside `<button>` is invalid HTML — browsers reparent the div outside the button, so `e.target.closest('.js-mcp-accordion')` never finds the button element
- **Style inconsistent**: custom bespoke accordion pattern + CSS instead of the app's standard `accordion-item` / `accordion-header js-accordion-toggle` / `accordion-body` pattern used everywhere else (e.g. admin/settings.php)
- **Fix**: migrated to the standard pattern; removed the now-dead `js-mcp-accordion` click handler, `toggleMcpAccordion` function, and custom CSS classes

## Test plan

- [ ] Navigate to Account → Access Tokens page
- [ ] Click each of the 7 MCP guide accordion rows — content should expand/collapse
- [ ] Verify visual styling matches the admin Settings accordions
- [ ] Chevron rotates on expand/collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the MCP Setup Guides accordion component layout and styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->