### PR TITLE
ui: subtle background tints for admin and superadmin areas

### DIFF
--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -227,11 +227,11 @@ main.container {
 
 /* === Admin / Superadmin page themes ======================================== */
 .admin-theme .app-content {
-    background: #f1f5f9;
+    background: #eef2ff;
 }
 
 .superadmin-theme .app-content {
-    background: #eff6ff;
+    background: #fdf4ff;
 }
 
 


### PR DESCRIPTION
## Summary

- Admin pages: `#eef2ff` (indigo-50) — a faint wash of the primary brand colour
- Superadmin pages: `#fdf4ff` (fuchsia-50) — a faint purple wash signalling elevated access

Both tints are a single visible step above the default page background (`#f8fafc`), distinct from each other, and non-distracting.

## Test plan
- [ ] Visit `/app/admin` — confirm subtle indigo tint on content area
- [ ] Visit `/superadmin` — confirm subtle purple tint on content area
- [ ] Regular app pages remain unchanged (`#f8fafc`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)