### PR TITLE
fix: render sounding board results as accordions

### DIFF
--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -2985,6 +2985,10 @@ tbody tr:hover {
     overflow: hidden;
 }
 
+.sb-accordion-item {
+    display: block;
+}
+
 /* Accordion header (replaces .persona-header) */
 .sb-accordion-item .sb-accordion-header {
     display: flex;
@@ -2999,10 +3003,15 @@ tbody tr:hover {
     color: var(--text);
     text-align: left;
     gap: 0.5rem;
+    list-style: none;
 }
 
 .sb-accordion-item .sb-accordion-header:hover {
     background: var(--surface-hover, rgba(0,0,0,0.04));
+}
+
+.sb-accordion-item .sb-accordion-header::-webkit-details-marker {
+    display: none;
 }
 
 .sb-accordion-title {
@@ -3026,6 +3035,7 @@ tbody tr:hover {
     color: var(--text-muted, #666);
 }
 
+.sb-accordion-item[open] .sb-accordion-chevron,
 .sb-accordion-item.sb-open .sb-accordion-chevron {
     transform: rotate(90deg);
 }
@@ -3037,6 +3047,7 @@ tbody tr:hover {
     border-top: 1px solid var(--border);
 }
 
+.sb-accordion-item[open] .sb-accordion-body,
 .sb-accordion-item.sb-open .sb-accordion-body {
     display: block;
 }

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -2756,36 +2756,49 @@ function runSoundingBoard() {
  * Handles bold, bullet lists, numbered lists, and headings.
  */
 function renderPersonaMarkdown(text) {
-    var lines = escapeHtml(text).split('\n');
+    var normalized = String(text || '').replace(/\r\n/g, '\n').replace(/\\n/g, '\n');
+    var lines = escapeHtml(normalized).split('\n');
     var out = [];
     var inUl = false;
     var inOl = false;
+
+    function inlineMarkdown(value) {
+        return value
+            .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+            .replace(/\*(.+?)\*/g, '<em>$1</em>');
+    }
+
+    function closeLists() {
+        if (inUl) { out.push('</ul>'); inUl = false; }
+        if (inOl) { out.push('</ol>'); inOl = false; }
+    }
 
     lines.forEach(function(line) {
         var ul = line.match(/^\s*[-*]\s+(.+)/);
         var ol = line.match(/^\s*\d+\.\s+(.+)/);
         var h = line.match(/^\s*#{1,4}\s+(.+)/);
+        var boldHeading = line.match(/^\s*\*\*([^*]+)\*\*\s*$/);
 
         if (ul) {
             if (!inUl) { if (inOl) { out.push('</ol>'); inOl = false; } out.push('<ul>'); inUl = true; }
-            out.push('<li>' + ul[1].replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>') + '</li>');
+            out.push('<li>' + inlineMarkdown(ul[1]) + '</li>');
         } else if (ol) {
             if (!inOl) { if (inUl) { out.push('</ul>'); inUl = false; } out.push('<ol>'); inOl = true; }
-            out.push('<li>' + ol[1].replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>') + '</li>');
+            out.push('<li>' + inlineMarkdown(ol[1]) + '</li>');
         } else {
-            if (inUl) { out.push('</ul>'); inUl = false; }
-            if (inOl) { out.push('</ol>'); inOl = false; }
+            closeLists();
             if (h) {
-                out.push('<p class="sb-section-heading">' + h[1].replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>') + '</p>');
+                out.push('<p class="sb-section-heading">' + inlineMarkdown(h[1]) + '</p>');
+            } else if (boldHeading) {
+                out.push('<p class="sb-section-heading">' + inlineMarkdown(boldHeading[0]) + '</p>');
             } else if (line.trim() === '') {
                 out.push('<br>');
             } else {
-                out.push('<p>' + line.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>') + '</p>');
+                out.push('<p>' + inlineMarkdown(line) + '</p>');
             }
         }
     });
-    if (inUl) out.push('</ul>');
-    if (inOl) out.push('</ol>');
+    closeLists();
     return out.join('');
 }
 
@@ -2828,13 +2841,12 @@ function renderSoundingBoardResults(data) {
         var risk = extractRiskRating(result.response);
         if (risk) { riskCounts[risk] = (riskCounts[risk] || 0) + 1; }
 
-        var item = document.createElement('div');
+        var item = document.createElement('details');
         item.className = 'sb-accordion-item persona-result';
         item.dataset.evalId = String(data.id);
         item.dataset.index = String(index);
 
-        var header = document.createElement('button');
-        header.type = 'button';
+        var header = document.createElement('summary');
         header.className = 'sb-accordion-header';
         header.setAttribute('aria-expanded', 'false');
 
@@ -2851,6 +2863,11 @@ function renderSoundingBoardResults(data) {
             riskBadge.textContent = risk;
             rightSpan.appendChild(riskBadge);
         }
+
+        var statusBadge = document.createElement('span');
+        statusBadge.className = 'persona-status badge badge-muted';
+        statusBadge.textContent = result.status || 'pending';
+        rightSpan.appendChild(statusBadge);
 
         var chevron = document.createElement('span');
         chevron.className = 'sb-accordion-chevron';
@@ -2892,10 +2909,8 @@ function renderSoundingBoardResults(data) {
         item.appendChild(body);
         container.appendChild(item);
 
-        header.addEventListener('click', function() {
-            var isOpen = item.classList.contains('sb-open');
-            item.classList.toggle('sb-open', !isOpen);
-            header.setAttribute('aria-expanded', String(!isOpen));
+        item.addEventListener('toggle', function() {
+            header.setAttribute('aria-expanded', String(item.open));
         });
     });
 
@@ -2904,11 +2919,11 @@ function renderSoundingBoardResults(data) {
     var summaryParts = summaryRisks.map(function(r) { return riskCounts[r] + '× ' + r; });
     var topRisk = summaryRisks[0] || null;
 
-    var conclusionItem = document.createElement('div');
-    conclusionItem.className = 'sb-accordion-item sb-conclusion sb-open';
+    var conclusionItem = document.createElement('details');
+    conclusionItem.className = 'sb-accordion-item sb-conclusion';
+    conclusionItem.open = true;
 
-    var conclusionHeader = document.createElement('button');
-    conclusionHeader.type = 'button';
+    var conclusionHeader = document.createElement('summary');
     conclusionHeader.className = 'sb-accordion-header';
     conclusionHeader.setAttribute('aria-expanded', 'true');
 
@@ -2955,10 +2970,8 @@ function renderSoundingBoardResults(data) {
     conclusionItem.appendChild(conclusionBody);
     container.appendChild(conclusionItem);
 
-    conclusionHeader.addEventListener('click', function() {
-        var isOpen = conclusionItem.classList.contains('sb-open');
-        conclusionItem.classList.toggle('sb-open', !isOpen);
-        conclusionHeader.setAttribute('aria-expanded', String(!isOpen));
+    conclusionItem.addEventListener('toggle', function() {
+        conclusionHeader.setAttribute('aria-expanded', String(conclusionItem.open));
     });
 }
 

--- a/tests/Playwright/fast/evaluation-board.spec.js
+++ b/tests/Playwright/fast/evaluation-board.spec.js
@@ -194,6 +194,33 @@ test.describe('Evaluation Board modal — UI smoke', () => {
     await expect(page.locator('#sounding-board-modal')).toBeAttached();
   });
 
+  test('Sounding Board results render as closed formatted accordions', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/app/work-items?project_id=1`);
+
+    await page.evaluate(() => {
+      renderSoundingBoardResults({
+        id: 123,
+        results: [{
+          role_title: 'CEO',
+          member_id: 1,
+          status: 'pending',
+          response: '1. **Overall Assessment**\\nThis is **important**.\\n\\n* **Key Concern:** prove the market.'
+        }]
+      });
+    });
+
+    const persona = page.locator('#sb-results details.persona-result').first();
+    await expect(persona).toBeAttached();
+    await expect(persona).not.toHaveAttribute('open', '');
+    await expect(persona.locator('summary')).toContainText('CEO');
+    await expect(persona.locator('strong').first()).toHaveText('Overall Assessment');
+    await expect(persona.locator('.persona-response')).toBeHidden();
+
+    const conclusion = page.locator('#sb-results details.sb-conclusion').first();
+    await expect(conclusion).toHaveAttribute('open', '');
+  });
+
   test('Board Review button and modal are present on work-items page', async ({ page }) => {
     await loginAsAdmin(page);
     // project_id=1 is the seeded demo project — required so the controller renders the template


### PR DESCRIPTION
## Summary
- render Sounding Board persona results as native closed accordions
- format markdown-style persona output instead of displaying raw **bold** markers
- keep the conclusion accordion open by default and add regression coverage

## Tests
- node --check public/assets/js/app.js
- npx playwright test fast/evaluation-board.spec.js --project=fast --grep "Sounding Board results render"
- npx playwright test fast/evaluation-board.spec.js --project=fast
- pre-push fast Playwright suite: 45 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added status indicator to persona results in the sounding board

**Improvements**
- Enhanced text formatting with improved newline normalization and support for inline bold and italic styles
- Improved list rendering with better structure management when transitioning between content types
- Extended heading recognition to support bold text patterns as section headings
- Converted accordion items to native HTML details/summary elements for improved accessibility and native browser interaction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->