### PR TITLE
test(e2e): expand Playwright coverage from 74 to 100 tests

### DIFF
--- a/tests/Playwright/fast/account-tokens.spec.js
+++ b/tests/Playwright/fast/account-tokens.spec.js
@@ -1,0 +1,46 @@
+// @ts-check
+/**
+ * Personal Access Token management page — smoke tests.
+ *
+ * Does NOT create real tokens (avoids leaving API keys in test DB state).
+ * Verifies the page loads and the create form is present.
+ */
+const { test, expect } = require('@playwright/test');
+const { ADMIN_EMAIL, ADMIN_PASS } = require('../test-constants');
+
+const BASE = process.env.BASE_URL || 'http://localhost:8890';
+
+async function loginAsAdmin(page) {
+  await page.goto(`${BASE}/login`);
+  await page.fill('input[name="email"]', ADMIN_EMAIL);
+  await page.fill('input[name="password"]', ADMIN_PASS);
+  await page.click('button[type="submit"]');
+  await expect(page).toHaveURL(`${BASE}/app/home`);
+  await page.evaluate(() => { if (typeof dismissOnboarding === 'function') dismissOnboarding(); }).catch(() => false);
+}
+
+test.describe('Account tokens page', () => {
+
+  test('loads without 500', async ({ page }) => {
+    await loginAsAdmin(page);
+    const response = await page.goto(`${BASE}/app/account/tokens`);
+    expect(response?.status()).toBe(200);
+    await expect(page.locator('body')).not.toContainText(/500|Fatal error|Uncaught|exception/i);
+  });
+
+  test('token creation form is visible', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/app/account/tokens`);
+    await expect(page.locator('body')).not.toContainText(/500|Fatal error/i);
+    // Form should exist — either visible or within a toggle/section
+    const form = page.locator('form[action*="/account/tokens"]');
+    expect(await form.count()).toBeGreaterThan(0);
+  });
+
+  test('unauthenticated request redirects to /login', async ({ page }) => {
+    const response = await page.goto(`${BASE}/app/account/tokens`);
+    await expect(page).toHaveURL(`${BASE}/login`);
+    expect(response?.status()).not.toBe(500);
+  });
+
+});

--- a/tests/Playwright/fast/api-auth.spec.js
+++ b/tests/Playwright/fast/api-auth.spec.js
@@ -1,0 +1,56 @@
+// @ts-check
+/**
+ * API auth tests — /api/v1/* routes must return 401 JSON (never HTML) when
+ * unauthenticated. This catches middleware bugs where auth failure returns an
+ * HTML redirect instead of a JSON error.
+ */
+const { test, expect } = require('@playwright/test');
+
+const BASE = process.env.BASE_URL || 'http://localhost:8890';
+
+async function fetchApi(page, path, token) {
+  return page.evaluate(async ({ url, token }) => {
+    const headers = token ? { Authorization: `Bearer ${token}` } : {};
+    const r = await fetch(url, { headers });
+    return {
+      status: r.status,
+      contentType: r.headers.get('content-type') ?? '',
+      text: await r.text(),
+    };
+  }, { url: `${BASE}${path}`, token: token ?? null });
+}
+
+test.describe('API auth — unauthenticated requests return 401 JSON', () => {
+
+  for (const path of ['/api/v1/me', '/api/v1/stories', '/api/v1/projects', '/api/v1/stories/team']) {
+    test(`GET ${path} without token → 401 JSON (not HTML redirect)`, async ({ page }) => {
+      await page.goto(`${BASE}/login`); // establishes page context without session
+      await page.evaluate(() => document.cookie.split(';').forEach(c => {
+        document.cookie = c.replace(/^ +/, '').replace(/=.*/, '=;expires=' + new Date(0).toUTCString() + ';path=/');
+      }));
+
+      const res = await fetchApi(page, path, null);
+
+      expect(res.status).toBe(401);
+      expect(res.contentType).toMatch(/application\/json/);
+      expect(res.text).not.toMatch(/<!DOCTYPE/i);
+      expect(res.text).not.toMatch(/<html/i);
+
+      const json = JSON.parse(res.text);
+      expect(json).toHaveProperty('error');
+    });
+  }
+
+  test('GET /api/v1/me with malformed token → 401 JSON', async ({ page }) => {
+    await page.goto(`${BASE}/login`);
+    const res = await fetchApi(page, '/api/v1/me', 'sf_pat_invalid_garbage_token');
+
+    expect(res.status).toBe(401);
+    expect(res.contentType).toMatch(/application\/json/);
+    expect(res.text).not.toMatch(/<!DOCTYPE/i);
+
+    const json = JSON.parse(res.text);
+    expect(json).toHaveProperty('error');
+  });
+
+});

--- a/tests/Playwright/fast/api-auth.spec.js
+++ b/tests/Playwright/fast/api-auth.spec.js
@@ -24,10 +24,8 @@ test.describe('API auth — unauthenticated requests return 401 JSON', () => {
 
   for (const path of ['/api/v1/me', '/api/v1/stories', '/api/v1/projects', '/api/v1/stories/team']) {
     test(`GET ${path} without token → 401 JSON (not HTML redirect)`, async ({ page }) => {
-      await page.goto(`${BASE}/login`); // establishes page context without session
-      await page.evaluate(() => document.cookie.split(';').forEach(c => {
-        document.cookie = c.replace(/^ +/, '').replace(/=.*/, '=;expires=' + new Date(0).toUTCString() + ';path=/');
-      }));
+      await page.goto(`${BASE}/login`);
+      await page.context().clearCookies(); // clearCookies removes HttpOnly cookies too
 
       const res = await fetchApi(page, path, null);
 

--- a/tests/Playwright/fast/board-review.spec.js
+++ b/tests/Playwright/fast/board-review.spec.js
@@ -42,49 +42,25 @@ async function postJson(page, url, body) {
 
 test.describe('Board Review button — visible on subscription-gated pages', () => {
 
-  test('button appears on /app/upload (summary screen)', async ({ page }) => {
-    await loginAsAdmin(page);
-    await page.goto(`${BASE}/app/upload`);
-    await expect(page.locator('body')).not.toContainText(/500|Fatal error|exception/i);
-    const btn = page.locator('button.board-review-trigger');
-    if (await btn.count() > 0) {
-      await expect(btn.first()).toBeVisible();
-      expect(await btn.first().getAttribute('data-screen')).toBe('summary');
-    }
-  });
+  for (const { path, screen } of [
+    { path: '/app/upload',       screen: 'summary'      },
+    { path: '/app/diagram',      screen: 'roadmap'      },
+    { path: '/app/work-items',   screen: 'work_items'   },
+    { path: '/app/user-stories', screen: 'user_stories' },
+  ]) {
+    test(`button appears on ${path} (${screen} screen)`, async ({ page }) => {
+      await loginAsAdmin(page);
+      await page.goto(`${BASE}${path}`);
+      await expect(page.locator('body')).not.toContainText(/500|Fatal error|exception/i);
 
-  test('button appears on /app/diagram (roadmap screen)', async ({ page }) => {
-    await loginAsAdmin(page);
-    await page.goto(`${BASE}/app/diagram`);
-    await expect(page.locator('body')).not.toContainText(/500|Fatal error|exception/i);
-    const btn = page.locator('button.board-review-trigger');
-    if (await btn.count() > 0) {
-      await expect(btn.first()).toBeVisible();
-      expect(await btn.first().getAttribute('data-screen')).toBe('roadmap');
-    }
-  });
+      // Pages redirect to /app/home when no project exists in seed — skip button check
+      if (!page.url().includes(path)) return;
 
-  test('button appears on /app/work-items (work_items screen)', async ({ page }) => {
-    await loginAsAdmin(page);
-    await page.goto(`${BASE}/app/work-items`);
-    await expect(page.locator('body')).not.toContainText(/500|Fatal error|exception/i);
-    const btn = page.locator('button.board-review-trigger');
-    if (await btn.count() > 0) {
+      const btn = page.locator('button.board-review-trigger');
       await expect(btn.first()).toBeVisible();
-      expect(await btn.first().getAttribute('data-screen')).toBe('work_items');
-    }
-  });
-
-  test('button appears on /app/user-stories (user_stories screen)', async ({ page }) => {
-    await loginAsAdmin(page);
-    await page.goto(`${BASE}/app/user-stories`);
-    await expect(page.locator('body')).not.toContainText(/500|Fatal error|exception/i);
-    const btn = page.locator('button.board-review-trigger');
-    if (await btn.count() > 0) {
-      await expect(btn.first()).toBeVisible();
-      expect(await btn.first().getAttribute('data-screen')).toBe('user_stories');
-    }
-  });
+      expect(await btn.first().getAttribute('data-screen')).toBe(screen);
+    });
+  }
 
 });
 

--- a/tests/Playwright/fast/board-review.spec.js
+++ b/tests/Playwright/fast/board-review.spec.js
@@ -1,0 +1,134 @@
+// @ts-check
+/**
+ * Board Review — button visibility and endpoint format tests.
+ *
+ * Does NOT trigger Gemini (project_id=0 fails at project lookup before AI).
+ * Validates: button renders on all 4 screens, evaluate always returns JSON.
+ */
+const { test, expect } = require('@playwright/test');
+const { ADMIN_EMAIL, ADMIN_PASS } = require('../test-constants');
+
+const BASE = process.env.BASE_URL || 'http://localhost:8890';
+
+async function loginAsAdmin(page) {
+  await page.goto(`${BASE}/login`);
+  await page.fill('input[name="email"]', ADMIN_EMAIL);
+  await page.fill('input[name="password"]', ADMIN_PASS);
+  await page.click('button[type="submit"]');
+  await expect(page).toHaveURL(`${BASE}/app/home`);
+  await page.evaluate(() => { if (typeof dismissOnboarding === 'function') dismissOnboarding(); }).catch(() => false);
+}
+
+async function getCsrfToken(page) {
+  return page.inputValue('input[name="_csrf_token"]');
+}
+
+async function postJson(page, url, body) {
+  return page.evaluate(async ({ url, body }) => {
+    const r = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+      body: JSON.stringify(body),
+    });
+    return {
+      status: r.status,
+      contentType: r.headers.get('content-type') ?? '',
+      text: await r.text(),
+    };
+  }, { url, body });
+}
+
+// ── Button visibility (requires has_evaluation_board = 1 on seed org) ────────
+
+test.describe('Board Review button — visible on subscription-gated pages', () => {
+
+  test('button appears on /app/upload (summary screen)', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/app/upload`);
+    await expect(page.locator('body')).not.toContainText(/500|Fatal error|exception/i);
+    const btn = page.locator('button.board-review-trigger');
+    if (await btn.count() > 0) {
+      await expect(btn.first()).toBeVisible();
+      expect(await btn.first().getAttribute('data-screen')).toBe('summary');
+    }
+  });
+
+  test('button appears on /app/diagram (roadmap screen)', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/app/diagram`);
+    await expect(page.locator('body')).not.toContainText(/500|Fatal error|exception/i);
+    const btn = page.locator('button.board-review-trigger');
+    if (await btn.count() > 0) {
+      await expect(btn.first()).toBeVisible();
+      expect(await btn.first().getAttribute('data-screen')).toBe('roadmap');
+    }
+  });
+
+  test('button appears on /app/work-items (work_items screen)', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/app/work-items`);
+    await expect(page.locator('body')).not.toContainText(/500|Fatal error|exception/i);
+    const btn = page.locator('button.board-review-trigger');
+    if (await btn.count() > 0) {
+      await expect(btn.first()).toBeVisible();
+      expect(await btn.first().getAttribute('data-screen')).toBe('work_items');
+    }
+  });
+
+  test('button appears on /app/user-stories (user_stories screen)', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/app/user-stories`);
+    await expect(page.locator('body')).not.toContainText(/500|Fatal error|exception/i);
+    const btn = page.locator('button.board-review-trigger');
+    if (await btn.count() > 0) {
+      await expect(btn.first()).toBeVisible();
+      expect(await btn.first().getAttribute('data-screen')).toBe('user_stories');
+    }
+  });
+
+});
+
+// ── Evaluate endpoint — must always return JSON, never HTML ──────────────────
+
+test.describe('Board Review evaluate endpoint — returns JSON for all screen contexts', () => {
+
+  for (const screenContext of ['summary', 'roadmap', 'work_items', 'user_stories']) {
+    test(`returns JSON for screen_context="${screenContext}"`, async ({ page }) => {
+      await loginAsAdmin(page);
+      await page.goto(`${BASE}/app/work-items`);
+      const csrf = await getCsrfToken(page);
+
+      const res = await postJson(page, `${BASE}/app/board-review/evaluate`, {
+        project_id: 0, // 0 → 404 JSON ("Project not found"), never HTML
+        evaluation_level: 'devils_advocate',
+        screen_context: screenContext,
+        screen_content: 'Playwright JSON-format assertion — no AI call needed',
+        _csrf_token: csrf,
+      });
+
+      // Core assertion: response must never be HTML (catches CSRF bugs, PHP exceptions)
+      expect(res.contentType).toMatch(/application\/json/);
+      expect(res.text).not.toMatch(/<!DOCTYPE/i);
+      expect(res.text).not.toMatch(/<html/i);
+
+      const json = JSON.parse(res.text);
+      expect(json).toBeDefined();
+      // project_id=0 → project not found; either error or ok are valid, but must be JSON
+      expect(typeof json === 'object').toBe(true);
+    });
+  }
+
+});
+
+// ── History page ─────────────────────────────────────────────────────────────
+
+test.describe('Board Review history page', () => {
+
+  test('loads without 500 and renders history heading', async ({ page }) => {
+    await loginAsAdmin(page);
+    const response = await page.goto(`${BASE}/app/board-review/history`);
+    expect(response?.status()).not.toBe(500);
+    await expect(page.locator('body')).not.toContainText(/500|Fatal error|Uncaught/i);
+  });
+
+});

--- a/tests/Playwright/fast/healthz.spec.js
+++ b/tests/Playwright/fast/healthz.spec.js
@@ -1,0 +1,24 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+const BASE = process.env.BASE_URL || 'http://localhost:8890';
+
+test.describe('/healthz endpoint', () => {
+
+  test('returns HTTP 200', async ({ page }) => {
+    const response = await page.goto(`${BASE}/healthz`);
+    expect(response?.status()).toBe(200);
+  });
+
+  test('returns JSON with ok status and no fatal errors', async ({ page }) => {
+    const response = await page.goto(`${BASE}/healthz`);
+    expect(response?.status()).toBe(200);
+    const contentType = response?.headers()['content-type'] ?? '';
+    expect(contentType).toMatch(/application\/json/);
+    const body = await response?.json();
+    expect(body).toHaveProperty('status');
+    expect(body.status).toBe('ok');
+    expect(body).toHaveProperty('db_ms');
+  });
+
+});

--- a/tests/Playwright/full/board-review-flow.spec.js
+++ b/tests/Playwright/full/board-review-flow.spec.js
@@ -67,19 +67,28 @@ test.describe('Board Review — evaluate flow (nightly, real Gemini call)', () =
 
     const json = JSON.parse(res.text);
 
-    // Possible outcomes: AI evaluation succeeded, or subscription gate / project gate
+    // Possible outcomes: AI evaluation succeeded, or known environment gates
     if (res.status === 201) {
-      // Successful AI evaluation — verify response shape
-      expect(json).toHaveProperty('id');
-      expect(json).toHaveProperty('recommendation');
-      // recommendation is an object: {summary, rationale, proposed_changes}
-      expect(json.recommendation).toHaveProperty('summary');
-      expect(json.recommendation).toHaveProperty('rationale');
-      expect(typeof json.recommendation.summary).toBe('string');
-      expect(json.recommendation.summary.length).toBeGreaterThan(10);
+      const reviewId = json.id;
+      try {
+        // Verify response shape
+        expect(json).toHaveProperty('id');
+        expect(json).toHaveProperty('recommendation');
+        // recommendation is an object: {summary, rationale, proposed_changes}
+        expect(json.recommendation).toHaveProperty('summary');
+        expect(json.recommendation).toHaveProperty('rationale');
+        expect(typeof json.recommendation.summary).toBe('string');
+        expect(json.recommendation.summary.length).toBeGreaterThan(10);
+      } finally {
+        // Clean up the pending review so it doesn't pollute seed state
+        const cleanupCsrf = await getCsrfToken(page);
+        await page.request.post(`${BASE}/app/board-review/${reviewId}/reject`, {
+          form: { _csrf_token: cleanupCsrf },
+        }).catch(() => {});
+      }
     } else {
-      // Acceptable failures: 403 (no subscription), 404 (no project), 400 (validation)
-      expect([400, 403, 404]).toContain(res.status);
+      // Only known environment gates are acceptable non-201 outcomes
+      expect([403, 404]).toContain(res.status);
       expect(json).toHaveProperty('error');
     }
   });
@@ -119,7 +128,6 @@ test.describe('Board Review — evaluate flow (nightly, real Gemini call)', () =
 
     const evalJson = JSON.parse(evalRes.text);
 
-    // If the evaluate succeeded (has id), test the reject flow
     if (evalRes.status === 201 && evalJson.id) {
       const reviewId = evalJson.id;
 
@@ -134,9 +142,12 @@ test.describe('Board Review — evaluate flow (nightly, real Gemini call)', () =
       const rejectJson = await rejectRes.json();
       expect(rejectJson).toHaveProperty('status', 'rejected');
       expect(rejectJson).toHaveProperty('id', reviewId);
-    } else {
-      // Subscription not enabled for seed org — skip gracefully
+    } else if ([403, 404].includes(evalRes.status)) {
+      // Known environment gates (no subscription or no project in seed) — skip
       test.skip(true, `Board Review not available (evaluate returned ${evalRes.status})`);
+    } else {
+      // Any other status is an unexpected failure — surface it
+      throw new Error(`Unexpected evaluate status ${evalRes.status}: ${evalRes.text}`);
     }
   });
 

--- a/tests/Playwright/full/board-review-flow.spec.js
+++ b/tests/Playwright/full/board-review-flow.spec.js
@@ -2,8 +2,10 @@
 /**
  * Board Review — end-to-end flow tests.
  *
- * Runs in the full/nightly suite only. Makes REAL Gemini API calls (1 per test).
- * Limited to 2 tests to keep nightly Gemini spend low.
+ * Runs in the full/nightly suite only. 2 Gemini calls across 3 tests:
+ *   - Test 1 (evaluate work_items): 1 Gemini call
+ *   - Test 2 (invalid screen_context): no Gemini call (fails validation first)
+ *   - Test 3 (reject flow): 1 Gemini call (evaluate to obtain a review id, then reject)
  *
  * Assumes: seed project_id=1 with at least one HL work item.
  */
@@ -128,8 +130,10 @@ test.describe('Board Review — evaluate flow (nightly, real Gemini call)', () =
         form: { _csrf_token: rejectCsrf },
       });
 
-      expect(rejectRes.status()).toBeLessThan(400);
-      await expect(page.locator('body')).not.toContainText(/500|Fatal error/i);
+      expect(rejectRes.status()).toBe(200);
+      const rejectJson = await rejectRes.json();
+      expect(rejectJson).toHaveProperty('status', 'rejected');
+      expect(rejectJson).toHaveProperty('id', reviewId);
     } else {
       // Subscription not enabled for seed org — skip gracefully
       test.skip(true, `Board Review not available (evaluate returned ${evalRes.status})`);

--- a/tests/Playwright/full/board-review-flow.spec.js
+++ b/tests/Playwright/full/board-review-flow.spec.js
@@ -1,0 +1,136 @@
+// @ts-check
+/**
+ * Board Review — end-to-end flow tests.
+ *
+ * Runs in the full/nightly suite only. Makes REAL Gemini API calls (1 per test).
+ * Limited to 2 tests to keep nightly Gemini spend low.
+ *
+ * Assumes: seed project_id=1 with at least one HL work item.
+ */
+const { test, expect } = require('@playwright/test');
+const { ADMIN_EMAIL, ADMIN_PASS } = require('../test-constants');
+
+const BASE       = process.env.BASE_URL || 'http://localhost:8890';
+const PROJECT_ID = 1;
+
+async function loginAsAdmin(page) {
+  await page.goto(`${BASE}/login`);
+  await page.fill('input[name="email"]', ADMIN_EMAIL);
+  await page.fill('input[name="password"]', ADMIN_PASS);
+  await page.click('button[type="submit"]');
+  await expect(page).toHaveURL(`${BASE}/app/home`);
+  await page.evaluate(() => { if (typeof dismissOnboarding === 'function') dismissOnboarding(); }).catch(() => false);
+}
+
+async function getCsrfToken(page) {
+  return page.inputValue('input[name="_csrf_token"]');
+}
+
+async function postJson(page, url, body) {
+  return page.evaluate(async ({ url, body }) => {
+    const r = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+      body: JSON.stringify(body),
+    });
+    return {
+      status: r.status,
+      contentType: r.headers.get('content-type') ?? '',
+      text: await r.text(),
+    };
+  }, { url, body });
+}
+
+test.describe('Board Review — evaluate flow (nightly, real Gemini call)', () => {
+
+  // Longer timeout — Gemini call can take 15-20 s under load
+  test.setTimeout(60_000);
+
+  test('evaluate work_items screen returns structured recommendation', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/app/work-items`);
+    const csrf = await getCsrfToken(page);
+
+    const res = await postJson(page, `${BASE}/app/board-review/evaluate`, {
+      project_id: PROJECT_ID,
+      evaluation_level: 'devils_advocate',
+      screen_context: 'work_items',
+      screen_content: 'Epic: Improve authentication system (8 pts). Epic: Redesign onboarding flow (5 pts). Epic: API rate limiting (3 pts).',
+      _csrf_token: csrf,
+    });
+
+    // Must always be JSON
+    expect(res.contentType).toMatch(/application\/json/);
+    expect(res.text).not.toMatch(/<!DOCTYPE/i);
+
+    const json = JSON.parse(res.text);
+
+    // Possible outcomes: AI evaluation succeeded, or subscription gate / project gate
+    if (res.status === 200) {
+      // Successful AI evaluation — verify response shape
+      expect(json).toHaveProperty('id');
+      expect(json).toHaveProperty('recommendation');
+      expect(typeof json.recommendation).toBe('string');
+      expect(json.recommendation.length).toBeGreaterThan(10);
+    } else {
+      // Acceptable failures: 403 (no subscription), 404 (no project), 400 (validation)
+      expect([400, 403, 404]).toContain(res.status);
+      expect(json).toHaveProperty('error');
+    }
+  });
+
+  test('evaluate with invalid screen_context returns 400 JSON', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/app/work-items`);
+    const csrf = await getCsrfToken(page);
+
+    const res = await postJson(page, `${BASE}/app/board-review/evaluate`, {
+      project_id: PROJECT_ID,
+      evaluation_level: 'devils_advocate',
+      screen_context: 'nonexistent_screen',  // invalid
+      screen_content: 'some content',
+      _csrf_token: csrf,
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.contentType).toMatch(/application\/json/);
+    const json = JSON.parse(res.text);
+    expect(json).toHaveProperty('error');
+  });
+
+  test('reject action returns JSON and sets status to rejected', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/app/work-items`);
+    const csrf = await getCsrfToken(page);
+
+    // First evaluate to get a review id (may cost 1 Gemini call)
+    const evalRes = await postJson(page, `${BASE}/app/board-review/evaluate`, {
+      project_id: PROJECT_ID,
+      evaluation_level: 'red_teaming',
+      screen_context: 'user_stories',
+      screen_content: 'Story: As a user I want to log in. Story: As an admin I want to manage users.',
+      _csrf_token: csrf,
+    });
+
+    const evalJson = JSON.parse(evalRes.text);
+
+    // If the evaluate succeeded (has id), test the reject flow
+    if (evalRes.status === 200 && evalJson.id) {
+      const reviewId = evalJson.id;
+
+      await page.goto(`${BASE}/app/work-items`);
+      const rejectCsrf = await getCsrfToken(page);
+
+      const rejectRes = await page.request.post(`${BASE}/app/board-review/${reviewId}/reject`, {
+        form: { _csrf_token: rejectCsrf },
+      });
+
+      expect(rejectRes.status()).toBeLessThan(400);
+      await expect(page.locator('body')).not.toContainText(/500|Fatal error/i);
+    } else {
+      // Subscription not enabled for seed org — skip gracefully
+      test.skip(true, `Board Review not available (evaluate returned ${evalRes.status})`);
+    }
+  });
+
+});

--- a/tests/Playwright/full/board-review-flow.spec.js
+++ b/tests/Playwright/full/board-review-flow.spec.js
@@ -66,12 +66,15 @@ test.describe('Board Review — evaluate flow (nightly, real Gemini call)', () =
     const json = JSON.parse(res.text);
 
     // Possible outcomes: AI evaluation succeeded, or subscription gate / project gate
-    if (res.status === 200) {
+    if (res.status === 201) {
       // Successful AI evaluation — verify response shape
       expect(json).toHaveProperty('id');
       expect(json).toHaveProperty('recommendation');
-      expect(typeof json.recommendation).toBe('string');
-      expect(json.recommendation.length).toBeGreaterThan(10);
+      // recommendation is an object: {summary, rationale, proposed_changes}
+      expect(json.recommendation).toHaveProperty('summary');
+      expect(json.recommendation).toHaveProperty('rationale');
+      expect(typeof json.recommendation.summary).toBe('string');
+      expect(json.recommendation.summary.length).toBeGreaterThan(10);
     } else {
       // Acceptable failures: 403 (no subscription), 404 (no project), 400 (validation)
       expect([400, 403, 404]).toContain(res.status);
@@ -115,7 +118,7 @@ test.describe('Board Review — evaluate flow (nightly, real Gemini call)', () =
     const evalJson = JSON.parse(evalRes.text);
 
     // If the evaluate succeeded (has id), test the reject flow
-    if (evalRes.status === 200 && evalJson.id) {
+    if (evalRes.status === 201 && evalJson.id) {
       const reviewId = evalJson.id;
 
       await page.goto(`${BASE}/app/work-items`);

--- a/tests/Playwright/full/key-results-crud.spec.js
+++ b/tests/Playwright/full/key-results-crud.spec.js
@@ -24,20 +24,25 @@ async function getCsrfToken(page) {
   return page.inputValue('input[name="_csrf_token"]');
 }
 
-/** Returns the HL work item id for the first item in project 1, or creates one. */
+/**
+ * Returns { id, cleanup } where cleanup() deletes the work item only if
+ * this helper created it. Callers must await cleanup() after their test.
+ */
 async function getOrCreateWorkItemId(page) {
-  // Try to find an existing delete-form action on work-items page to extract an id
   await page.goto(`${BASE}/app/work-items`);
   const deleteForm = page.locator('form[action*="/app/work-items/"][action*="/delete"]').first();
   if (await deleteForm.count() > 0) {
     const action = await deleteForm.getAttribute('action') ?? '';
     const match = action.match(/\/work-items\/(\d+)\/delete/);
-    if (match) return parseInt(match[1], 10);
+    if (match) {
+      const id = parseInt(match[1], 10);
+      return { id, cleanup: async () => {} }; // pre-existing — caller must not delete it
+    }
   }
 
-  // No existing item — create one and return its id
+  // No existing item — create one and return a cleanup fn
   const csrf = await getCsrfToken(page);
-  const res = await page.request.post(`${BASE}/app/work-items/store`, {
+  await page.request.post(`${BASE}/app/work-items/store`, {
     form: {
       _csrf_token: csrf,
       project_id: String(PROJECT_ID),
@@ -46,14 +51,24 @@ async function getOrCreateWorkItemId(page) {
       estimated_sprints: '1',
     },
   });
-  expect(res.status()).toBeLessThan(400);
 
-  // Re-load and extract id from delete form
   await page.goto(`${BASE}/app/work-items`);
   const form = page.locator('form[action*="/app/work-items/"][action*="/delete"]').first();
   const action = await form.getAttribute('action') ?? '';
   const match = action.match(/\/work-items\/(\d+)\/delete/);
-  return match ? parseInt(match[1], 10) : 0;
+  const id = match ? parseInt(match[1], 10) : 0;
+
+  return {
+    id,
+    cleanup: async () => {
+      if (!id) return;
+      await page.goto(`${BASE}/app/work-items`);
+      const delCsrf = await getCsrfToken(page);
+      await page.request.post(`${BASE}/app/work-items/${id}/delete`, {
+        form: { _csrf_token: delCsrf },
+      }).catch(() => {});
+    },
+  };
 }
 
 test.describe('Key Results CRUD', () => {
@@ -61,8 +76,9 @@ test.describe('Key Results CRUD', () => {
   test('create a key result → verify it appears → delete it', async ({ page }) => {
     await loginAsAdmin(page);
 
-    const workItemId = await getOrCreateWorkItemId(page);
+    const { id: workItemId, cleanup: cleanupWorkItem } = await getOrCreateWorkItemId(page);
     expect(workItemId).toBeGreaterThan(0);
+    try {
 
     await page.goto(`${BASE}/app/key-results`);
     const csrf = await getCsrfToken(page);
@@ -98,6 +114,9 @@ test.describe('Key Results CRUD', () => {
       form: { _csrf_token: delCsrf },
     });
     expect(deleteRes.status()).toBeLessThan(400);
+    } finally {
+      await cleanupWorkItem();
+    }
   });
 
   test('create returns 400 with missing hl_work_item_id', async ({ page }) => {
@@ -119,7 +138,7 @@ test.describe('Key Results CRUD', () => {
 
   test('create returns 400 when title is empty', async ({ page }) => {
     await loginAsAdmin(page);
-    const workItemId = await getOrCreateWorkItemId(page);
+    const { id: workItemId, cleanup: cleanupWorkItem } = await getOrCreateWorkItemId(page);
     await page.goto(`${BASE}/app/key-results`);
     const csrf = await getCsrfToken(page);
 
@@ -131,11 +150,12 @@ test.describe('Key Results CRUD', () => {
       },
     });
     expect(res.status()).toBe(400);
+    await cleanupWorkItem();
   });
 
   test('update changes current_value and returns ok', async ({ page }) => {
     await loginAsAdmin(page);
-    const workItemId = await getOrCreateWorkItemId(page);
+    const { id: workItemId, cleanup: cleanupWorkItem } = await getOrCreateWorkItemId(page);
     await page.goto(`${BASE}/app/key-results`);
     const csrf = await getCsrfToken(page);
 
@@ -167,12 +187,13 @@ test.describe('Key Results CRUD', () => {
     });
     expect(updateRes.status()).toBeLessThan(400);
 
-    // Cleanup
+    // Cleanup KR then work item
     await page.goto(`${BASE}/app/key-results`);
     const delCsrf = await getCsrfToken(page);
     await page.request.post(`${BASE}/app/key-results/${krId}/delete`, {
       form: { _csrf_token: delCsrf },
     });
+    await cleanupWorkItem();
   });
 
 });

--- a/tests/Playwright/full/key-results-crud.spec.js
+++ b/tests/Playwright/full/key-results-crud.spec.js
@@ -29,7 +29,7 @@ async function getCsrfToken(page) {
  * this helper created it. Callers must await cleanup() after their test.
  */
 async function getOrCreateWorkItemId(page) {
-  await page.goto(`${BASE}/app/work-items`);
+  await page.goto(`${BASE}/app/work-items?project_id=${PROJECT_ID}`);
   const deleteForm = page.locator('form[action*="/app/work-items/"][action*="/delete"]').first();
   if (await deleteForm.count() > 0) {
     const action = await deleteForm.getAttribute('action') ?? '';
@@ -52,7 +52,7 @@ async function getOrCreateWorkItemId(page) {
     },
   });
 
-  await page.goto(`${BASE}/app/work-items`);
+  await page.goto(`${BASE}/app/work-items?project_id=${PROJECT_ID}`);
   const form = page.locator('form[action*="/app/work-items/"][action*="/delete"]').first();
   const action = await form.getAttribute('action') ?? '';
   const match = action.match(/\/work-items\/(\d+)\/delete/);
@@ -62,13 +62,23 @@ async function getOrCreateWorkItemId(page) {
     id,
     cleanup: async () => {
       if (!id) return;
-      await page.goto(`${BASE}/app/work-items`);
+      await page.goto(`${BASE}/app/work-items?project_id=${PROJECT_ID}`);
       const delCsrf = await getCsrfToken(page);
       await page.request.post(`${BASE}/app/work-items/${id}/delete`, {
         form: { _csrf_token: delCsrf },
       }).catch(() => {});
     },
   };
+}
+
+async function deleteKr(page, krId) {
+  try {
+    await page.goto(`${BASE}/app/key-results`);
+    const delCsrf = await getCsrfToken(page);
+    await page.request.post(`${BASE}/app/key-results/${krId}/delete`, {
+      form: { _csrf_token: delCsrf },
+    }).catch(() => {});
+  } catch (_) { /* best-effort cleanup */ }
 }
 
 test.describe('Key Results CRUD', () => {
@@ -78,43 +88,46 @@ test.describe('Key Results CRUD', () => {
 
     const { id: workItemId, cleanup: cleanupWorkItem } = await getOrCreateWorkItemId(page);
     expect(workItemId).toBeGreaterThan(0);
+
+    let krId = null;
     try {
+      await page.goto(`${BASE}/app/key-results`);
+      const csrf = await getCsrfToken(page);
 
-    await page.goto(`${BASE}/app/key-results`);
-    const csrf = await getCsrfToken(page);
+      const uniqueTitle = `PW Key Result ${Date.now()}`;
 
-    const uniqueTitle = `PW Key Result ${Date.now()}`;
+      // Create
+      const createRes = await page.request.post(`${BASE}/app/key-results`, {
+        form: {
+          _csrf_token: csrf,
+          hl_work_item_id: String(workItemId),
+          title: uniqueTitle,
+          metric_description: 'Automated test metric',
+          baseline_value: '0',
+          target_value: '100',
+          current_value: '10',
+          unit: '%',
+        },
+      });
+      expect(createRes.status()).toBeLessThan(400);
+      const createJson = await createRes.json();
+      expect(createJson).toHaveProperty('id');
+      krId = createJson.id;
 
-    // Create
-    const createRes = await page.request.post(`${BASE}/app/key-results`, {
-      form: {
-        _csrf_token: csrf,
-        hl_work_item_id: String(workItemId),
-        title: uniqueTitle,
-        metric_description: 'Automated test metric',
-        baseline_value: '0',
-        target_value: '100',
-        current_value: '10',
-        unit: '%',
-      },
-    });
-    expect(createRes.status()).toBeLessThan(400);
-    const createJson = await createRes.json();
-    expect(createJson).toHaveProperty('id');
-    const krId = createJson.id;
+      // Verify page loads without error (KR should now be in DB)
+      await page.goto(`${BASE}/app/key-results`);
+      await expect(page.locator('body')).not.toContainText(/500|Fatal error|Uncaught/i);
 
-    // Verify page loads without error (KR should now be in DB)
-    await page.goto(`${BASE}/app/key-results`);
-    await expect(page.locator('body')).not.toContainText(/500|Fatal error|Uncaught/i);
-
-    // Delete
-    await page.goto(`${BASE}/app/key-results`);
-    const delCsrf = await getCsrfToken(page);
-    const deleteRes = await page.request.post(`${BASE}/app/key-results/${krId}/delete`, {
-      form: { _csrf_token: delCsrf },
-    });
-    expect(deleteRes.status()).toBeLessThan(400);
+      // Delete (assertion step — proves endpoint works)
+      await page.goto(`${BASE}/app/key-results`);
+      const delCsrf = await getCsrfToken(page);
+      const deleteRes = await page.request.post(`${BASE}/app/key-results/${krId}/delete`, {
+        form: { _csrf_token: delCsrf },
+      });
+      expect(deleteRes.status()).toBeLessThan(400);
+      krId = null; // deleted — skip finally cleanup
     } finally {
+      if (krId) await deleteKr(page, krId);
       await cleanupWorkItem();
     }
   });
@@ -139,61 +152,62 @@ test.describe('Key Results CRUD', () => {
   test('create returns 400 when title is empty', async ({ page }) => {
     await loginAsAdmin(page);
     const { id: workItemId, cleanup: cleanupWorkItem } = await getOrCreateWorkItemId(page);
-    await page.goto(`${BASE}/app/key-results`);
-    const csrf = await getCsrfToken(page);
+    try {
+      await page.goto(`${BASE}/app/key-results`);
+      const csrf = await getCsrfToken(page);
 
-    const res = await page.request.post(`${BASE}/app/key-results`, {
-      form: {
-        _csrf_token: csrf,
-        hl_work_item_id: String(workItemId),
-        title: '',
-      },
-    });
-    expect(res.status()).toBe(400);
-    await cleanupWorkItem();
+      const res = await page.request.post(`${BASE}/app/key-results`, {
+        form: {
+          _csrf_token: csrf,
+          hl_work_item_id: String(workItemId),
+          title: '',
+        },
+      });
+      expect(res.status()).toBe(400);
+    } finally {
+      await cleanupWorkItem();
+    }
   });
 
   test('update changes current_value and returns ok', async ({ page }) => {
     await loginAsAdmin(page);
     const { id: workItemId, cleanup: cleanupWorkItem } = await getOrCreateWorkItemId(page);
-    await page.goto(`${BASE}/app/key-results`);
-    const csrf = await getCsrfToken(page);
+    let krId = null;
+    try {
+      await page.goto(`${BASE}/app/key-results`);
+      const csrf = await getCsrfToken(page);
 
-    // Create
-    const createRes = await page.request.post(`${BASE}/app/key-results`, {
-      form: {
-        _csrf_token: csrf,
-        hl_work_item_id: String(workItemId),
-        title: `PW KR Update ${Date.now()}`,
-        baseline_value: '0',
-        target_value: '50',
-        current_value: '5',
-        unit: 'pts',
-      },
-    });
-    const krId = (await createRes.json()).id;
+      // Create
+      const createRes = await page.request.post(`${BASE}/app/key-results`, {
+        form: {
+          _csrf_token: csrf,
+          hl_work_item_id: String(workItemId),
+          title: `PW KR Update ${Date.now()}`,
+          baseline_value: '0',
+          target_value: '50',
+          current_value: '5',
+          unit: 'pts',
+        },
+      });
+      krId = (await createRes.json()).id;
 
-    // Update
-    await page.goto(`${BASE}/app/key-results`);
-    const updateCsrf = await getCsrfToken(page);
-    const updateRes = await page.request.post(`${BASE}/app/key-results/${krId}`, {
-      form: {
-        _csrf_token: updateCsrf,
-        hl_work_item_id: String(workItemId),
-        title: `PW KR Update ${krId}`,
-        current_value: '25',
-        target_value: '50',
-      },
-    });
-    expect(updateRes.status()).toBeLessThan(400);
-
-    // Cleanup KR then work item
-    await page.goto(`${BASE}/app/key-results`);
-    const delCsrf = await getCsrfToken(page);
-    await page.request.post(`${BASE}/app/key-results/${krId}/delete`, {
-      form: { _csrf_token: delCsrf },
-    });
-    await cleanupWorkItem();
+      // Update
+      await page.goto(`${BASE}/app/key-results`);
+      const updateCsrf = await getCsrfToken(page);
+      const updateRes = await page.request.post(`${BASE}/app/key-results/${krId}`, {
+        form: {
+          _csrf_token: updateCsrf,
+          hl_work_item_id: String(workItemId),
+          title: `PW KR Update ${krId}`,
+          current_value: '25',
+          target_value: '50',
+        },
+      });
+      expect(updateRes.status()).toBeLessThan(400);
+    } finally {
+      if (krId) await deleteKr(page, krId);
+      await cleanupWorkItem();
+    }
   });
 
 });

--- a/tests/Playwright/full/key-results-crud.spec.js
+++ b/tests/Playwright/full/key-results-crud.spec.js
@@ -132,6 +132,9 @@ test.describe('Key Results CRUD', () => {
         form: { _csrf_token: delCsrf },
       });
       expect(deleteRes.status()).toBeLessThan(400);
+      expect(await deleteRes.json()).toEqual(expect.objectContaining({ ok: true }));
+      await page.goto(`${BASE}/app/key-results`);
+      await expect(page.locator('body')).not.toContainText(uniqueTitle);
       krId = null; // deleted — skip finally cleanup
     } finally {
       if (krId) await deleteKr(page, krId);
@@ -171,6 +174,8 @@ test.describe('Key Results CRUD', () => {
         },
       });
       expect(res.status()).toBe(400);
+      const json = await res.json();
+      expect(json).toHaveProperty('error');
     } finally {
       await cleanupWorkItem();
     }
@@ -218,6 +223,7 @@ test.describe('Key Results CRUD', () => {
       expect(await updateRes.json()).toEqual(expect.objectContaining({ ok: true }));
       await page.goto(`${BASE}/app/key-results`);
       await expect(page.locator('body')).toContainText(updatedTitle);
+      await expect(page.locator('body')).toContainText('25');
     } finally {
       if (krId) await deleteKr(page, krId);
       await cleanupWorkItem();

--- a/tests/Playwright/full/key-results-crud.spec.js
+++ b/tests/Playwright/full/key-results-crud.spec.js
@@ -42,7 +42,7 @@ async function getOrCreateWorkItemId(page) {
 
   // No existing item — create one and return a cleanup fn
   const csrf = await getCsrfToken(page);
-  await page.request.post(`${BASE}/app/work-items/store`, {
+  const createRes = await page.request.post(`${BASE}/app/work-items/store`, {
     form: {
       _csrf_token: csrf,
       project_id: String(PROJECT_ID),
@@ -51,22 +51,28 @@ async function getOrCreateWorkItemId(page) {
       estimated_sprints: '1',
     },
   });
+  expect(createRes.status()).toBeLessThan(400);
 
   await page.goto(`${BASE}/app/work-items?project_id=${PROJECT_ID}`);
   const form = page.locator('form[action*="/app/work-items/"][action*="/delete"]').first();
   const action = await form.getAttribute('action') ?? '';
   const match = action.match(/\/work-items\/(\d+)\/delete/);
-  const id = match ? parseInt(match[1], 10) : 0;
+  if (!match) {
+    throw new Error(`Failed to recover fallback work item id after creation; action="${action}"`);
+  }
+  const id = parseInt(match[1], 10);
 
   return {
     id,
     cleanup: async () => {
-      if (!id) return;
-      await page.goto(`${BASE}/app/work-items?project_id=${PROJECT_ID}`);
-      const delCsrf = await getCsrfToken(page);
-      await page.request.post(`${BASE}/app/work-items/${id}/delete`, {
-        form: { _csrf_token: delCsrf },
-      }).catch(() => {});
+      try {
+        if (!id) return;
+        await page.goto(`${BASE}/app/work-items?project_id=${PROJECT_ID}`);
+        const delCsrf = await getCsrfToken(page);
+        await page.request.post(`${BASE}/app/work-items/${id}/delete`, {
+          form: { _csrf_token: delCsrf },
+        }).catch(() => {});
+      } catch (_) { /* best-effort cleanup */ }
     },
   };
 }

--- a/tests/Playwright/full/key-results-crud.spec.js
+++ b/tests/Playwright/full/key-results-crud.spec.js
@@ -1,0 +1,178 @@
+// @ts-check
+/**
+ * Key Results CRUD — create, verify, update, delete.
+ *
+ * Assumes seed data provides at least one HL work item (project_id=1, id=1).
+ * Each test creates uniquely-named data to avoid cross-test pollution.
+ */
+const { test, expect } = require('@playwright/test');
+const { ADMIN_EMAIL, ADMIN_PASS } = require('../test-constants');
+
+const BASE         = process.env.BASE_URL || 'http://localhost:8890';
+const PROJECT_ID   = 1;   // seed project
+
+async function loginAsAdmin(page) {
+  await page.goto(`${BASE}/login`);
+  await page.fill('input[name="email"]', ADMIN_EMAIL);
+  await page.fill('input[name="password"]', ADMIN_PASS);
+  await page.click('button[type="submit"]');
+  await expect(page).toHaveURL(`${BASE}/app/home`);
+  await page.evaluate(() => { if (typeof dismissOnboarding === 'function') dismissOnboarding(); }).catch(() => false);
+}
+
+async function getCsrfToken(page) {
+  return page.inputValue('input[name="_csrf_token"]');
+}
+
+/** Returns the HL work item id for the first item in project 1, or creates one. */
+async function getOrCreateWorkItemId(page) {
+  // Try to find an existing delete-form action on work-items page to extract an id
+  await page.goto(`${BASE}/app/work-items`);
+  const deleteForm = page.locator('form[action*="/app/work-items/"][action*="/delete"]').first();
+  if (await deleteForm.count() > 0) {
+    const action = await deleteForm.getAttribute('action') ?? '';
+    const match = action.match(/\/work-items\/(\d+)\/delete/);
+    if (match) return parseInt(match[1], 10);
+  }
+
+  // No existing item — create one and return its id
+  const csrf = await getCsrfToken(page);
+  const res = await page.request.post(`${BASE}/app/work-items/store`, {
+    form: {
+      _csrf_token: csrf,
+      project_id: String(PROJECT_ID),
+      title: `KR Test Work Item ${Date.now()}`,
+      description: 'Created by key-results-crud Playwright test',
+      estimated_sprints: '1',
+    },
+  });
+  expect(res.status()).toBeLessThan(400);
+
+  // Re-load and extract id from delete form
+  await page.goto(`${BASE}/app/work-items`);
+  const form = page.locator('form[action*="/app/work-items/"][action*="/delete"]').first();
+  const action = await form.getAttribute('action') ?? '';
+  const match = action.match(/\/work-items\/(\d+)\/delete/);
+  return match ? parseInt(match[1], 10) : 0;
+}
+
+test.describe('Key Results CRUD', () => {
+
+  test('create a key result → verify it appears → delete it', async ({ page }) => {
+    await loginAsAdmin(page);
+
+    const workItemId = await getOrCreateWorkItemId(page);
+    expect(workItemId).toBeGreaterThan(0);
+
+    await page.goto(`${BASE}/app/key-results`);
+    const csrf = await getCsrfToken(page);
+
+    const uniqueTitle = `PW Key Result ${Date.now()}`;
+
+    // Create
+    const createRes = await page.request.post(`${BASE}/app/key-results`, {
+      form: {
+        _csrf_token: csrf,
+        hl_work_item_id: String(workItemId),
+        title: uniqueTitle,
+        metric_description: 'Automated test metric',
+        baseline_value: '0',
+        target_value: '100',
+        current_value: '10',
+        unit: '%',
+      },
+    });
+    expect(createRes.status()).toBeLessThan(400);
+    const createJson = await createRes.json();
+    expect(createJson).toHaveProperty('id');
+    const krId = createJson.id;
+
+    // Verify page loads without error (KR should now be in DB)
+    await page.goto(`${BASE}/app/key-results`);
+    await expect(page.locator('body')).not.toContainText(/500|Fatal error|Uncaught/i);
+
+    // Delete
+    await page.goto(`${BASE}/app/key-results`);
+    const delCsrf = await getCsrfToken(page);
+    const deleteRes = await page.request.post(`${BASE}/app/key-results/${krId}/delete`, {
+      form: { _csrf_token: delCsrf },
+    });
+    expect(deleteRes.status()).toBeLessThan(400);
+  });
+
+  test('create returns 400 with missing hl_work_item_id', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/app/key-results`);
+    const csrf = await getCsrfToken(page);
+
+    const res = await page.request.post(`${BASE}/app/key-results`, {
+      form: {
+        _csrf_token: csrf,
+        hl_work_item_id: '0',
+        title: 'Should fail',
+      },
+    });
+    expect(res.status()).toBe(400);
+    const json = await res.json();
+    expect(json).toHaveProperty('error');
+  });
+
+  test('create returns 400 when title is empty', async ({ page }) => {
+    await loginAsAdmin(page);
+    const workItemId = await getOrCreateWorkItemId(page);
+    await page.goto(`${BASE}/app/key-results`);
+    const csrf = await getCsrfToken(page);
+
+    const res = await page.request.post(`${BASE}/app/key-results`, {
+      form: {
+        _csrf_token: csrf,
+        hl_work_item_id: String(workItemId),
+        title: '',
+      },
+    });
+    expect(res.status()).toBe(400);
+  });
+
+  test('update changes current_value and returns ok', async ({ page }) => {
+    await loginAsAdmin(page);
+    const workItemId = await getOrCreateWorkItemId(page);
+    await page.goto(`${BASE}/app/key-results`);
+    const csrf = await getCsrfToken(page);
+
+    // Create
+    const createRes = await page.request.post(`${BASE}/app/key-results`, {
+      form: {
+        _csrf_token: csrf,
+        hl_work_item_id: String(workItemId),
+        title: `PW KR Update ${Date.now()}`,
+        baseline_value: '0',
+        target_value: '50',
+        current_value: '5',
+        unit: 'pts',
+      },
+    });
+    const krId = (await createRes.json()).id;
+
+    // Update
+    await page.goto(`${BASE}/app/key-results`);
+    const updateCsrf = await getCsrfToken(page);
+    const updateRes = await page.request.post(`${BASE}/app/key-results/${krId}`, {
+      form: {
+        _csrf_token: updateCsrf,
+        hl_work_item_id: String(workItemId),
+        title: `PW KR Update ${krId}`,
+        current_value: '25',
+        target_value: '50',
+      },
+    });
+    expect(updateRes.status()).toBeLessThan(400);
+
+    // Cleanup
+    await page.goto(`${BASE}/app/key-results`);
+    const delCsrf = await getCsrfToken(page);
+    await page.request.post(`${BASE}/app/key-results/${krId}/delete`, {
+      form: { _csrf_token: delCsrf },
+    });
+  });
+
+});

--- a/tests/Playwright/full/key-results-crud.spec.js
+++ b/tests/Playwright/full/key-results-crud.spec.js
@@ -2,7 +2,7 @@
 /**
  * Key Results CRUD — create, verify, update, delete.
  *
- * Assumes seed data provides at least one HL work item (project_id=1, id=1).
+ * Uses seed project_id=1 and creates a temporary HL work item when none exists.
  * Each test creates uniquely-named data to avoid cross-test pollution.
  */
 const { test, expect } = require('@playwright/test');
@@ -114,9 +114,10 @@ test.describe('Key Results CRUD', () => {
       expect(createJson).toHaveProperty('id');
       krId = createJson.id;
 
-      // Verify page loads without error (KR should now be in DB)
+      // Verify page loads without error and KR is present
       await page.goto(`${BASE}/app/key-results`);
       await expect(page.locator('body')).not.toContainText(/500|Fatal error|Uncaught/i);
+      await expect(page.locator('body')).toContainText(uniqueTitle);
 
       // Delete (assertion step — proves endpoint works)
       await page.goto(`${BASE}/app/key-results`);
@@ -189,21 +190,28 @@ test.describe('Key Results CRUD', () => {
           unit: 'pts',
         },
       });
-      krId = (await createRes.json()).id;
+      expect(createRes.status()).toBeLessThan(400);
+      const createJson = await createRes.json();
+      expect(createJson).toHaveProperty('id');
+      krId = createJson.id;
 
       // Update
       await page.goto(`${BASE}/app/key-results`);
       const updateCsrf = await getCsrfToken(page);
+      const updatedTitle = `PW KR Update ${krId}`;
       const updateRes = await page.request.post(`${BASE}/app/key-results/${krId}`, {
         form: {
           _csrf_token: updateCsrf,
           hl_work_item_id: String(workItemId),
-          title: `PW KR Update ${krId}`,
+          title: updatedTitle,
           current_value: '25',
           target_value: '50',
         },
       });
       expect(updateRes.status()).toBeLessThan(400);
+      expect(await updateRes.json()).toEqual(expect.objectContaining({ ok: true }));
+      await page.goto(`${BASE}/app/key-results`);
+      await expect(page.locator('body')).toContainText(updatedTitle);
     } finally {
       if (krId) await deleteKr(page, krId);
       await cleanupWorkItem();


### PR DESCRIPTION
## Summary

- **+26 tests** across 6 new spec files, bringing coverage from 74 → 100 tests (~20 → ~28 pages)

**fast/ suite (every PR):**
- `healthz.spec.js` — `/healthz` returns 200 + `{status:'ok'}` JSON (was never tested)
- `board-review.spec.js` — Board Review button visible on 4 screens; `evaluate` endpoint always returns JSON not HTML for all 4 `screen_context` values (catches CSRF/exception bugs)
- `api-auth.spec.js` — `/api/v1/*` returns 401 JSON when unauthenticated or token is malformed (catches middleware returning HTML redirect instead of JSON)
- `account-tokens.spec.js` — token management page loads, form visible, unauthed redirect

**full/ suite (nightly):**
- `key-results-crud.spec.js` — create/update/delete a Key Result via `KrController`; validates 400 responses for missing required fields
- `board-review-flow.spec.js` — 1 real Gemini call for `work_items` evaluate; invalid `screen_context` returns 400; reject flow sets status to rejected. Limited to minimal AI calls to control nightly spend.

## Test plan

- [ ] CI: Playwright (fast) green with new fast specs passing
- [ ] CI: PHPUnit unaffected (no PHP src changes)
- [ ] CI: test-touch gate skipped (test-only commit)
- [ ] Nightly: key-results-crud and board-review-flow run against staging

## Security notes

N/A — test-only change. No new PHP source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Playwright suites: Account Tokens, API auth (unauthenticated 401 JSON checks), Board Review (UI, evaluate/history), healthz, and Key Results CRUD.
  * Added full end-to-end Board Review flow (evaluate/reject against real backend) and full Key Results create/update/delete scenarios.
  * Expanded coverage for subscription-gated pages, CSRF-protected actions, response content-type and body checks, and unauthenticated API response shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->