### PR TITLE
fix(e2e): expose renderSoundingBoardResults globally to fix Playwright test

### DIFF
--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -2974,6 +2974,7 @@ function renderSoundingBoardResults(data) {
         conclusionHeader.setAttribute('aria-expanded', String(conclusionItem.open));
     });
 }
+window.renderSoundingBoardResults = renderSoundingBoardResults;
 
 /**
  * Accept or reject a single persona's evaluation response.


### PR DESCRIPTION
## Summary

- `renderSoundingBoardResults` was defined inside the top-level IIFE in `public/assets/js/app.js`, making it inaccessible to `page.evaluate()` in Playwright tests
- Added `window.renderSoundingBoardResults = renderSoundingBoardResults;` after the function definition so the test at `fast/evaluation-board.spec.js:197` can call it globally
- One-line fix; no behaviour change for users

## Root Cause

`app.js` is wrapped in a single `(function() { ... })();` IIFE. All functions inside it are module-scoped. `page.evaluate(() => { renderSoundingBoardResults({...}) })` fails with `ReferenceError` because the function isn't on `window`. Adding `window.X = X` inside the IIFE is the standard bridge.

## Test Plan

- [ ] CI: `fast/evaluation-board.spec.js:197` Sounding Board results render test passes
- [ ] CI: Deploy to Railway unblocked (E2E was the only failing gate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal infrastructure adjustment with no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->