### PR TITLE
fix(ci): fix 3 nightly failures — infection config, smoke skip, push guard

### DIFF
--- a/.github/workflows/nightly-triage.yml
+++ b/.github/workflows/nightly-triage.yml
@@ -136,7 +136,7 @@ jobs:
             echo "No history changes"
           else
             git commit -m "chore: nightly CI history ${DATE}"
-            git push
+            git push || echo "::warning::Could not push history to main (branch protection). History preserved in triage-report artifact."
           fi
 
       - name: Notify on any failures

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -183,5 +183,5 @@ jobs:
             echo "No changes to commit"
           else
             git commit -m "chore: k6 performance history ${DATE}"
-            git push
+            git push || echo "::warning::Could not push performance history to main (branch protection). Results preserved in artifacts."
           fi

--- a/.github/workflows/smoke-staging.yml
+++ b/.github/workflows/smoke-staging.yml
@@ -16,9 +16,23 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      - name: Check STAGING_URL configured
+        id: precheck
+        env:
+          STAGING_URL: ${{ secrets.STAGING_URL }}
+        run: |
+          if [ -z "$STAGING_URL" ]; then
+            echo "::warning::STAGING_URL secret not set — skipping smoke suite"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        if: steps.precheck.outputs.skip == 'false'
 
       - name: Setup Node
+        if: steps.precheck.outputs.skip == 'false'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '20'
@@ -26,14 +40,17 @@ jobs:
           cache-dependency-path: tests/Playwright/package-lock.json
 
       - name: Install Playwright
+        if: steps.precheck.outputs.skip == 'false'
         working-directory: tests/Playwright
         run: npm ci
 
       - name: Install Chromium browser
+        if: steps.precheck.outputs.skip == 'false'
         working-directory: tests/Playwright
         run: npx playwright install chromium --with-deps
 
       - name: Run fast smoke against staging
+        if: steps.precheck.outputs.skip == 'false'
         working-directory: tests/Playwright
         env:
           CI: 'true'
@@ -43,7 +60,7 @@ jobs:
         run: npx playwright test --project=fast fast/
 
       - name: Upload artifacts on failure
-        if: failure()
+        if: failure() && steps.precheck.outputs.skip == 'false'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: smoke-staging-artifacts
@@ -55,7 +72,11 @@ jobs:
         run: |
           python3 - <<'PYEOF'
           import json, os
-          status = "fail" if os.environ.get("JOB_STATUS") != "success" else "pass"
+          skip = os.environ.get("SKIP") == "true"
+          if skip:
+              status = "skip"
+          else:
+              status = "fail" if os.environ.get("JOB_STATUS") != "success" else "pass"
           payload = {
               "job": "smoke",
               "status": status,
@@ -68,6 +89,7 @@ jobs:
           PYEOF
         env:
           JOB_STATUS: ${{ job.status }}
+          SKIP: ${{ steps.precheck.outputs.skip }}
 
       - name: Upload nightly status artifact
         if: always()

--- a/infection.json
+++ b/infection.json
@@ -21,6 +21,6 @@
     "phpUnit": {
         "configDir": "tests"
     },
-    "testFrameworkOptions": "--configuration tests/phpunit.xml",
+    "testFrameworkOptions": "--configuration=tests/phpunit.xml",
     "threads": 2
 }


### PR DESCRIPTION
## Summary

Three nightly CI failures traced to root cause and fixed in one commit:

- **mutation (issue #78):** `infection.json` was passing `--configuration tests/phpunit.xml` as a single argv token to PHPUnit 12.5.22. PHPUnit 12.5 rejects this as an unknown option — infection 0.32.6 doesn't split the option correctly. Fix: use `=` separator (`--configuration=tests/phpunit.xml`) so it's recognised as a single token in the `--flag=value` form.

- **smoke (issue #80):** `smoke-staging.yml` falls back to `localhost:8890` when `STAGING_URL` is absent. No server runs there in the nightly CI runner, so all login-dependent tests timeout after 16s. Fix: precheck step exits early with a warning and writes `status: skip` to the nightly status artifact instead of `fail`.

- **nightly-triage + performance (implicit):** Both workflows try `git push` to main to update history markdown. Branch protection (`dismiss_stale_reviews_on_push: true`, require-PR rule) rejects the push, failing the entire workflow. Fix: append `|| warning` so the push failure is non-fatal. History data is preserved in the uploaded `triage-report` / `nightly-status-perf` artifacts regardless.

## Closes

Fixes #78, #80. Issue #79 (perf-load) was a false positive — k6 ran successfully (p95=391ms, checks_failed=0.96%) but the push failure caused the whole workflow to report failure.

## Test Plan

- [ ] Next nightly run: mutation MSI reported correctly (not "unknown")
- [ ] Next nightly run: smoke reports `skip` instead of `fail` when no staging URL
- [ ] Next nightly run: nightly-triage workflow completes without error even if git push is blocked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow stability: push failures now emit warnings and preserve generated reports instead of halting workflows.
  * Optimized testing by conditionally skipping staging tests when required environment configuration is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->