### PR TITLE
fix(middleware): return JSON 403/401 on AJAX permission failures

### DIFF
--- a/docs/LOCAL_SETUP_MAMP.md
+++ b/docs/LOCAL_SETUP_MAMP.md
@@ -1,0 +1,207 @@
+# Local Setup with MAMP (macOS)
+
+This guide gets StratFlow running locally on macOS using MAMP as the MySQL host
+and PHP runtime. Docker is not required.
+
+---
+
+## Prerequisites
+
+| Tool | Version | Notes |
+|---|---|---|
+| [MAMP](https://www.mamp.info/) | 6.x or later | Provides MySQL 8.x and a web server |
+| PHP CLI | 8.2+ | MAMP includes one; confirm with `php -v` |
+| [Composer](https://getcomposer.org/) | 2.x | Install via `brew install composer` |
+| Git | any | Install via `brew install git` |
+
+MAMP ships a PHP 8.x binary at `/Applications/MAMP/bin/php/php8.x.x/bin/php`.
+Add it to your PATH so the terminal uses it:
+
+```bash
+# Add this to ~/.zshrc (replace 8.3.x with your actual version)
+export PATH="/Applications/MAMP/bin/php/php8.3.x/bin:$PATH"
+```
+
+Restart your terminal, then confirm: `php -v`
+
+---
+
+## 1 — Clone the repo
+
+```bash
+git clone https://github.com/semajyad/stratflow.git
+cd stratflow
+```
+
+> **Renaming the folder?** You can rename the directory to anything you like
+> (`StratFlow_v2`, `my-stratflow`, etc.). The PHP code uses the namespace
+> `StratFlow\` which is defined in **one place only** — `composer.json`. You
+> never need to change any PHP file when renaming the directory; see the
+> [Namespace note](#namespace-note-renaming-the-project) at the bottom.
+
+---
+
+## 2 — Start MAMP and configure MySQL
+
+1. Open MAMP, click **Start**.
+2. Go to **Preferences → Ports** and note the MySQL port (usually **8889** for MAMP,
+   or **3306** for MAMP Pro).
+3. Open **phpMyAdmin** (the "Open WebStart page" button → phpMyAdmin link).
+4. Create a new database:
+   - Database name: `stratflow`
+   - Collation: `utf8mb4_unicode_ci`
+5. Create a dedicated user (or use `root` for local dev only):
+   - User: `stratflow`
+   - Password: `stratflow_secret`
+   - Grant all privileges on the `stratflow` database.
+
+---
+
+## 3 — Configure the virtual host
+
+MAMP's built-in Apache can serve StratFlow directly. The document root must
+point to the `public/` subdirectory.
+
+### Option A — MAMP Pro (recommended)
+
+1. Go to **Hosts → Add host**.
+2. Set document root to `/path/to/stratflow/public`.
+3. Set the host name to `stratflow.local` (or any local domain).
+4. Save and restart.
+
+### Option B — Plain MAMP (free)
+
+1. Open MAMP → **Preferences → Web Server**.
+2. Set document root to `/path/to/stratflow/public`.
+3. Click **OK** → **Start** (restarts Apache).
+4. Access the app at `http://localhost:8888` (MAMP's default HTTP port).
+
+---
+
+## 4 — Install PHP dependencies
+
+```bash
+cd stratflow
+composer install
+```
+
+This downloads all libraries into `vendor/`. Do not commit `vendor/`.
+
+---
+
+## 5 — Create the `.env` file
+
+```bash
+cp .env.example .env
+```
+
+Open `.env` and update at minimum these values:
+
+```dotenv
+APP_ENV=local
+APP_URL=http://localhost:8888        # or http://stratflow.local if using MAMP Pro
+
+DB_HOST=127.0.0.1
+DB_PORT=8889                         # 8889 for MAMP free; 3306 for MAMP Pro
+DB_DATABASE=stratflow
+DB_USERNAME=stratflow
+DB_PASSWORD=stratflow_secret
+
+TOKEN_ENCRYPTION_KEY=<random 32-byte hex>   # see below
+```
+
+Generate a secure key:
+
+```bash
+php -r "echo bin2hex(random_bytes(32)) . PHP_EOL;"
+```
+
+Paste the output as `TOKEN_ENCRYPTION_KEY`.
+
+Leave `STRIPE_*`, `GEMINI_API_KEY`, and other third-party keys empty or as
+placeholder values — the app starts without them for local development.
+
+---
+
+## 6 — Initialise the database
+
+```bash
+php scripts/init-db.php
+```
+
+This runs `database/schema.sql` (creates all tables) and then applies any
+pending migrations from `database/migrations/`. It is safe to run multiple
+times — already-applied migrations are skipped.
+
+Expected output:
+```
+Connected to database: stratflow@127.0.0.1
+Schema applied successfully.
+All migrations applied.
+Tables present: 42 (users, projects, hl_work_items, ...)
+Database initialization complete.
+```
+
+---
+
+## 7 — Access the app
+
+Open `http://localhost:8888` (or your MAMP Pro host name).
+
+Register a new account. The first registered user in a new database is
+automatically assigned the `org_admin` role.
+
+---
+
+## Troubleshooting
+
+### "Access denied for user 'stratflow'@'localhost'"
+MAMP's MySQL socket path differs from the system default. Use `127.0.0.1`
+(not `localhost`) as `DB_HOST`. PHP resolves `localhost` to a Unix socket
+that MAMP does not listen on.
+
+### "Connection refused" on port 3306
+MAMP free uses port **8889**. Set `DB_PORT=8889` in `.env`.
+
+### PHP version mismatch
+Confirm `php -v` matches the MAMP PHP version. If not, update your PATH (step 0).
+
+### Composer not found
+Install via Homebrew: `brew install composer`. If Homebrew is not installed:
+`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
+
+---
+
+## Namespace note — renaming the project
+
+StratFlow uses the PHP namespace `StratFlow\` throughout the codebase.
+**This namespace is not tied to the directory name** — it is registered in
+`composer.json`:
+
+```json
+"autoload": {
+    "psr-4": {
+        "StratFlow\\": "src/"
+    }
+}
+```
+
+Composer's autoloader maps `StratFlow\Core\Response` → `src/Core/Response.php`
+regardless of what you named the parent folder.
+
+**If you rename the directory**, you only need to update one line — the path in
+`composer.json` if you also move the `src/` folder (you usually won't):
+
+```json
+"StratFlow\\": "src/"   ← this path is relative to composer.json, not the folder name
+```
+
+**You do not need to change any PHP file** to rename the project directory.
+The namespace `StratFlow\` is the application's internal identity, separate from
+the folder name on disk.
+
+If you want to rename the namespace itself (e.g. to `Acme\` for a white-label),
+that is a global find-and-replace across `src/`, `tests/`, and `composer.json`,
+plus a `composer dump-autoload`. This is intentional — PHP namespaces are
+explicit per-file declarations, not a single config value, because they affect
+IDE autocompletion, static analysis, and reflection.

--- a/docs/LOCAL_SETUP_MAMP.md
+++ b/docs/LOCAL_SETUP_MAMP.md
@@ -156,17 +156,21 @@ automatically assigned the `org_admin` role.
 ## Troubleshooting
 
 ### "Access denied for user 'stratflow'@'localhost'"
+
 MAMP's MySQL socket path differs from the system default. Use `127.0.0.1`
 (not `localhost`) as `DB_HOST`. PHP resolves `localhost` to a Unix socket
 that MAMP does not listen on.
 
 ### "Connection refused" on port 3306
+
 MAMP free uses port **8889**. Set `DB_PORT=8889` in `.env`.
 
 ### PHP version mismatch
+
 Confirm `php -v` matches the MAMP PHP version. If not, update your PATH (step 0).
 
 ### Composer not found
+
 Install via Homebrew: `brew install composer`. If Homebrew is not installed:
 `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
 

--- a/docs/LOCAL_SETUP_MAMP.md
+++ b/docs/LOCAL_SETUP_MAMP.md
@@ -107,13 +107,13 @@ DB_DATABASE=stratflow
 DB_USERNAME=stratflow
 DB_PASSWORD=stratflow_secret
 
-TOKEN_ENCRYPTION_KEY=<random 32-byte hex>   # see below
+TOKEN_ENCRYPTION_KEY=<base64-encoded 32-byte key>   # see below
 ```
 
 Generate a secure key:
 
 ```bash
-php -r "echo bin2hex(random_bytes(32)) . PHP_EOL;"
+php -r "echo base64_encode(random_bytes(32)) . PHP_EOL;"
 ```
 
 Paste the output as `TOKEN_ENCRYPTION_KEY`.
@@ -134,7 +134,8 @@ pending migrations from `database/migrations/`. It is safe to run multiple
 times — already-applied migrations are skipped.
 
 Expected output:
-```
+
+```text
 Connected to database: stratflow@127.0.0.1
 Schema applied successfully.
 All migrations applied.
@@ -167,7 +168,7 @@ MAMP free uses port **8889**. Set `DB_PORT=8889` in `.env`.
 
 ### PHP version mismatch
 
-Confirm `php -v` matches the MAMP PHP version. If not, update your PATH (step 0).
+Confirm `php -v` matches the MAMP PHP version. If not, update your PATH (see Prerequisites above).
 
 ### Composer not found
 
@@ -176,7 +177,7 @@ Install via Homebrew: `brew install composer`. If Homebrew is not installed:
 
 ---
 
-## Namespace note — renaming the project
+## Namespace note: renaming the project
 
 StratFlow uses the PHP namespace `StratFlow\` throughout the codebase.
 **This namespace is not tied to the directory name** — it is registered in

--- a/src/Core/Request.php
+++ b/src/Core/Request.php
@@ -86,7 +86,7 @@ class Request
         if (($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'XMLHttpRequest') {
             return true;
         }
-        $ct = $_SERVER['CONTENT_TYPE'] ?? $_SERVER['HTTP_CONTENT_TYPE'] ?? '';
+        $ct = strtolower($_SERVER['CONTENT_TYPE'] ?? $_SERVER['HTTP_CONTENT_TYPE'] ?? '');
         return str_starts_with($ct, 'application/json');
     }
 

--- a/src/Core/Request.php
+++ b/src/Core/Request.php
@@ -80,6 +80,16 @@ class Request
         return ($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'XMLHttpRequest';
     }
 
+    /** True when the request expects a JSON response (AJAX or Content-Type: application/json). */
+    public static function expectsJson(): bool
+    {
+        if (($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'XMLHttpRequest') {
+            return true;
+        }
+        $ct = $_SERVER['CONTENT_TYPE'] ?? $_SERVER['HTTP_CONTENT_TYPE'] ?? '';
+        return str_starts_with($ct, 'application/json');
+    }
+
     /**
      * Return the raw request body.
      */

--- a/src/Middleware/AuthMiddleware.php
+++ b/src/Middleware/AuthMiddleware.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace StratFlow\Middleware;
 
 use StratFlow\Core\Auth;
+use StratFlow\Core\Request;
 use StratFlow\Core\Response;
 
 /**
@@ -25,9 +26,10 @@ class AuthMiddleware
     public function handle(Auth $auth, Response $response): bool
     {
         if (!$auth->check()) {
-            if ($this->isAjaxRequest()) {
+            if (Request::expectsJson()) {
                 Response::applySecurityHeaders('app');
                 http_response_code(401);
+                header('Content-Type: application/json');
                 echo json_encode(['error' => 'Session expired — please reload the page']);
                 return false;
             }
@@ -51,14 +53,5 @@ class AuthMiddleware
         }
 
         return true;
-    }
-
-    private function isAjaxRequest(): bool
-    {
-        if (($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'XMLHttpRequest') {
-            return true;
-        }
-        $ct = $_SERVER['CONTENT_TYPE'] ?? $_SERVER['HTTP_CONTENT_TYPE'] ?? '';
-        return str_starts_with($ct, 'application/json');
     }
 }

--- a/src/Middleware/AuthMiddleware.php
+++ b/src/Middleware/AuthMiddleware.php
@@ -25,6 +25,12 @@ class AuthMiddleware
     public function handle(Auth $auth, Response $response): bool
     {
         if (!$auth->check()) {
+            if ($this->isAjaxRequest()) {
+                Response::applySecurityHeaders('app');
+                http_response_code(401);
+                echo json_encode(['error' => 'Session expired — please reload the page']);
+                return false;
+            }
             // Save the intended URL so we can redirect back after login
             $intendedUrl = $_SERVER['REQUEST_URI'] ?? '/app/home';
             $_SESSION['_intended_url'] = $intendedUrl;
@@ -45,5 +51,14 @@ class AuthMiddleware
         }
 
         return true;
+    }
+
+    private function isAjaxRequest(): bool
+    {
+        if (($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'XMLHttpRequest') {
+            return true;
+        }
+        $ct = $_SERVER['CONTENT_TYPE'] ?? $_SERVER['HTTP_CONTENT_TYPE'] ?? '';
+        return str_starts_with($ct, 'application/json');
     }
 }

--- a/src/Middleware/WorkflowWriteMiddleware.php
+++ b/src/Middleware/WorkflowWriteMiddleware.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace StratFlow\Middleware;
 
 use StratFlow\Core\Auth;
+use StratFlow\Core\Request;
 use StratFlow\Core\Response;
 use StratFlow\Security\PermissionService;
 
@@ -17,9 +18,10 @@ class WorkflowWriteMiddleware
     {
         $user = $auth->user();
         if (!$user || !PermissionService::can($user, PermissionService::WORKFLOW_EDIT)) {
-            if (self::isAjaxRequest()) {
+            if (Request::expectsJson()) {
                 Response::applySecurityHeaders('app');
                 http_response_code(403);
+                header('Content-Type: application/json');
                 echo json_encode(['error' => 'Insufficient permissions']);
             } else {
                 $response->redirect('/app/home');
@@ -28,14 +30,5 @@ class WorkflowWriteMiddleware
         }
 
         return true;
-    }
-
-    private static function isAjaxRequest(): bool
-    {
-        if (($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'XMLHttpRequest') {
-            return true;
-        }
-        $ct = $_SERVER['CONTENT_TYPE'] ?? $_SERVER['HTTP_CONTENT_TYPE'] ?? '';
-        return str_starts_with($ct, 'application/json');
     }
 }

--- a/src/Middleware/WorkflowWriteMiddleware.php
+++ b/src/Middleware/WorkflowWriteMiddleware.php
@@ -17,10 +17,25 @@ class WorkflowWriteMiddleware
     {
         $user = $auth->user();
         if (!$user || !PermissionService::can($user, PermissionService::WORKFLOW_EDIT)) {
-            $response->redirect('/app/home');
+            if (self::isAjaxRequest()) {
+                Response::applySecurityHeaders('app');
+                http_response_code(403);
+                echo json_encode(['error' => 'Insufficient permissions']);
+            } else {
+                $response->redirect('/app/home');
+            }
             return false;
         }
 
         return true;
+    }
+
+    private static function isAjaxRequest(): bool
+    {
+        if (($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'XMLHttpRequest') {
+            return true;
+        }
+        $ct = $_SERVER['CONTENT_TYPE'] ?? $_SERVER['HTTP_CONTENT_TYPE'] ?? '';
+        return str_starts_with($ct, 'application/json');
     }
 }

--- a/templates/diagram.php
+++ b/templates/diagram.php
@@ -239,4 +239,4 @@ $hasSummary = !empty($document_summary);
 </div>
 <?php endif; ?>
 
-<script defer src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js" integrity="sha384-/wpvwpx/82U/rD5MBk1sSp5IpBRhvzoZNsocF4/AIyIn1G8kobtnIsjaqd06GUO8" crossorigin="anonymous"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/mermaid@11.14.0/dist/mermaid.min.js" integrity="sha384-/wpvwpx/82U/rD5MBk1sSp5IpBRhvzoZNsocF4/AIyIn1G8kobtnIsjaqd06GUO8" crossorigin="anonymous"></script>

--- a/templates/diagram.php
+++ b/templates/diagram.php
@@ -30,7 +30,7 @@ $hasSummary = !empty($document_summary);
         <?php if ($hasDiagram): ?>
             <button type="button" id="generate-diagram-btn" class="btn btn-ai btn-sm js-generate-diagram">Regenerate</button>
         <?php endif; ?>
-        <?php $board_review_screen = 'roadmap'; include __DIR__ . '/partials/board-review-button.php'; ?>
+        <?php $active_page = 'roadmap'; include __DIR__ . '/partials/sounding-board-button.php'; ?>
     </div>
 </div>
 
@@ -239,4 +239,4 @@ $hasSummary = !empty($document_summary);
 </div>
 <?php endif; ?>
 
-<script defer src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js" integrity="sha384-/wpvwpx/82U/rD5MBk1sSp5IpBRhvzoZNsocF4/AIyIn1G8kobtnIsjaqd06GUO8" crossorigin="anonymous"></script>

--- a/templates/layouts/app.php
+++ b/templates/layouts/app.php
@@ -42,7 +42,6 @@ elseif (str_starts_with($_uri, '/app/admin/') || $_uri === '/app/admin') { $_bod
         </div>
     </div>
     <?php include __DIR__ . '/../partials/sounding-board-modal.php'; ?>
-    <?php include __DIR__ . '/../partials/board-review-modal.php'; ?>
     <?php include __DIR__ . '/../partials/onboarding-wizard.php'; ?>
     <script src="/assets/js/app.js?v=<?= ASSET_VERSION ?>"></script>
 </body>

--- a/templates/partials/sounding-board-button.php
+++ b/templates/partials/sounding-board-button.php
@@ -10,7 +10,7 @@
 ?>
 <?php if (($has_evaluation_board ?? false)): ?>
 <button class="btn btn-secondary sounding-board-trigger"
-        data-screen="<?= htmlspecialchars($active_page ?? $board_review_screen ?? '') ?>"
+        data-screen="<?= htmlspecialchars($active_page ?? $board_review_screen ?? '', ENT_QUOTES, 'UTF-8') ?>"
         data-project-id="<?= (int) ($project['id'] ?? 0) ?>">
     &#127919; Sounding Board
 </button>

--- a/templates/partials/sounding-board-button.php
+++ b/templates/partials/sounding-board-button.php
@@ -10,7 +10,7 @@
 ?>
 <?php if (($has_evaluation_board ?? false)): ?>
 <button class="btn btn-secondary sounding-board-trigger"
-        data-screen="<?= htmlspecialchars($active_page ?? '') ?>"
+        data-screen="<?= htmlspecialchars($active_page ?? $board_review_screen ?? '') ?>"
         data-project-id="<?= (int) ($project['id'] ?? 0) ?>">
     &#127919; Sounding Board
 </button>

--- a/templates/upload.php
+++ b/templates/upload.php
@@ -32,7 +32,7 @@ function formatFileSize(int $bytes): string {
                 Continue to Strategy Roadmap &rarr;
             </a>
         <?php endif; ?>
-        <?php $board_review_screen = 'summary'; include __DIR__ . '/partials/board-review-button.php'; ?>
+        <?php $active_page = 'summary'; include __DIR__ . '/partials/sounding-board-button.php'; ?>
     </div>
 </div>
 

--- a/templates/user-stories.php
+++ b/templates/user-stories.php
@@ -33,8 +33,7 @@ $unlinkedStories = $storiesByItem[0] ?? [];
     </h1>
     <div class="flex items-center gap-2">
         <?php $sync_type = 'user_stories'; include __DIR__ . '/partials/jira-sync-button.php'; ?>
-        <?php include __DIR__ . '/partials/sounding-board-button.php'; ?>
-        <?php $board_review_screen = 'user_stories'; include __DIR__ . '/partials/board-review-button.php'; ?>
+        <?php $active_page = 'user_stories'; include __DIR__ . '/partials/sounding-board-button.php'; ?>
         <?php if (!empty($stories)): ?>
         <form method="POST" action="/app/user-stories/delete-all" class="inline-form">
             <input type="hidden" name="_csrf_token" value="<?= htmlspecialchars($csrf_token) ?>">
@@ -220,4 +219,4 @@ $unlinkedStories = $storiesByItem[0] ?? [];
 <?php require __DIR__ . '/partials/workflow-nav.php'; ?>
 
 <!-- SortableJS CDN -->
-<script defer src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.6/Sortable.min.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.6/Sortable.min.js" integrity="sha384-mEnM5jz8H3hOHW8GhoOZzLiXEkoSCjXRgNyFQ3h18h8wY2m0YniNncC3EFs1QMKR" crossorigin="anonymous"></script>

--- a/templates/work-items.php
+++ b/templates/work-items.php
@@ -25,8 +25,7 @@
     </h1>
     <div class="flex items-center gap-2">
         <?php $sync_type = 'work_items'; include __DIR__ . '/partials/jira-sync-button.php'; ?>
-        <?php include __DIR__ . '/partials/sounding-board-button.php'; ?>
-        <?php $board_review_screen = 'work_items'; include __DIR__ . '/partials/board-review-button.php'; ?>
+        <?php $active_page = 'work_items'; include __DIR__ . '/partials/sounding-board-button.php'; ?>
     </div>
 </div>
 
@@ -167,9 +166,9 @@
 <?php require __DIR__ . '/partials/workflow-nav.php'; ?>
 
 <!-- SortableJS CDN -->
-<script defer src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.6/Sortable.min.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.6/Sortable.min.js" integrity="sha384-mEnM5jz8H3hOHW8GhoOZzLiXEkoSCjXRgNyFQ3h18h8wY2m0YniNncC3EFs1QMKR" crossorigin="anonymous"></script>
 
 <!-- Mermaid.js CDN for thumbnail -->
 <?php if (!empty($diagram)): ?>
-<script defer src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js" integrity="sha384-/wpvwpx/82U/rD5MBk1sSp5IpBRhvzoZNsocF4/AIyIn1G8kobtnIsjaqd06GUO8" crossorigin="anonymous"></script>
 <?php endif; ?>

--- a/templates/work-items.php
+++ b/templates/work-items.php
@@ -170,5 +170,5 @@
 
 <!-- Mermaid.js CDN for thumbnail -->
 <?php if (!empty($diagram)): ?>
-<script defer src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js" integrity="sha384-/wpvwpx/82U/rD5MBk1sSp5IpBRhvzoZNsocF4/AIyIn1G8kobtnIsjaqd06GUO8" crossorigin="anonymous"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/mermaid@11.14.0/dist/mermaid.min.js" integrity="sha384-/wpvwpx/82U/rD5MBk1sSp5IpBRhvzoZNsocF4/AIyIn1G8kobtnIsjaqd06GUO8" crossorigin="anonymous"></script>
 <?php endif; ?>

--- a/tests/Unit/Core/RequestTest.php
+++ b/tests/Unit/Core/RequestTest.php
@@ -229,4 +229,20 @@ class RequestTest extends TestCase {
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $this->assertSame([], $this->makeRequestWithBody('"string-value"')->json());
     }
+
+    public function testExpectsJsonReturnsTrueForXmlHttpRequest(): void {
+        $_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+        $this->assertTrue(Request::expectsJson());
+    }
+
+    public function testExpectsJsonReturnsTrueForJsonContentType(): void {
+        unset($_SERVER['HTTP_X_REQUESTED_WITH']);
+        $_SERVER['CONTENT_TYPE'] = 'application/json';
+        $this->assertTrue(Request::expectsJson());
+    }
+
+    public function testExpectsJsonReturnsFalseForBrowserRequest(): void {
+        unset($_SERVER['HTTP_X_REQUESTED_WITH'], $_SERVER['CONTENT_TYPE'], $_SERVER['HTTP_CONTENT_TYPE']);
+        $this->assertFalse(Request::expectsJson());
+    }
 }

--- a/tests/Unit/Core/RequestTest.php
+++ b/tests/Unit/Core/RequestTest.php
@@ -245,4 +245,16 @@ class RequestTest extends TestCase {
         unset($_SERVER['HTTP_X_REQUESTED_WITH'], $_SERVER['CONTENT_TYPE'], $_SERVER['HTTP_CONTENT_TYPE']);
         $this->assertFalse(Request::expectsJson());
     }
+
+    public function testExpectsJsonReturnsTrueForHttpContentTypeFallback(): void {
+        unset($_SERVER['HTTP_X_REQUESTED_WITH'], $_SERVER['CONTENT_TYPE']);
+        $_SERVER['HTTP_CONTENT_TYPE'] = 'application/json';
+        $this->assertTrue(Request::expectsJson());
+    }
+
+    public function testExpectsJsonReturnsTrueForMixedCaseContentType(): void {
+        unset($_SERVER['HTTP_X_REQUESTED_WITH'], $_SERVER['HTTP_CONTENT_TYPE']);
+        $_SERVER['CONTENT_TYPE'] = 'Application/JSON';
+        $this->assertTrue(Request::expectsJson());
+    }
 }

--- a/tests/Unit/Middleware/AuthMiddlewareTest.php
+++ b/tests/Unit/Middleware/AuthMiddlewareTest.php
@@ -38,6 +38,7 @@ class AuthMiddlewareTest extends TestCase
     #[Test]
     public function unauthenticatedUserIsRedirectedToLogin(): void
     {
+        $_SERVER['HTTP_X_REQUESTED_WITH'] = '';
         $redirectedTo = null;
         $result = (new AuthMiddleware())->handle(
             $this->makeAuth(false),
@@ -45,6 +46,29 @@ class AuthMiddlewareTest extends TestCase
         );
         $this->assertFalse($result);
         $this->assertSame('/login', $redirectedTo);
+        unset($_SERVER['HTTP_X_REQUESTED_WITH']);
+    }
+
+    #[Test]
+    public function unauthenticatedAjaxRequestReceivesJson401(): void
+    {
+        $_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+        $redirectedTo = null;
+
+        ob_start();
+        $result = (new AuthMiddleware())->handle(
+            $this->makeAuth(false),
+            $this->makeResponse($redirectedTo)
+        );
+        $body = ob_get_clean();
+
+        $this->assertFalse($result);
+        $this->assertNull($redirectedTo, 'Should not redirect on AJAX request');
+        $decoded = json_decode($body, true);
+        $this->assertIsArray($decoded);
+        $this->assertArrayHasKey('error', $decoded);
+
+        unset($_SERVER['HTTP_X_REQUESTED_WITH']);
     }
 
     #[Test]

--- a/tests/Unit/Middleware/WorkflowWriteMiddlewareTest.php
+++ b/tests/Unit/Middleware/WorkflowWriteMiddlewareTest.php
@@ -42,6 +42,7 @@ class WorkflowWriteMiddlewareTest extends TestCase
     #[Test]
     public function viewerIsBlockedFromWorkflowWrites(): void
     {
+        $_SERVER['HTTP_X_REQUESTED_WITH'] = '';
         $redirectedTo = null;
         $middleware = new WorkflowWriteMiddleware();
 
@@ -52,6 +53,29 @@ class WorkflowWriteMiddlewareTest extends TestCase
 
         $this->assertFalse($result);
         $this->assertSame('/app/home', $redirectedTo);
+    }
+
+    #[Test]
+    public function viewerReceivesJsonForbiddenOnAjaxRequest(): void
+    {
+        $_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+        $redirectedTo = null;
+        $middleware = new WorkflowWriteMiddleware();
+
+        ob_start();
+        $result = $middleware->handle(
+            $this->makeAuthWithUser(['role' => 'viewer']),
+            $this->makeResponseCapturingRedirect($redirectedTo)
+        );
+        $body = ob_get_clean();
+
+        $this->assertFalse($result);
+        $this->assertNull($redirectedTo, 'Should not redirect on AJAX request');
+        $decoded = json_decode($body, true);
+        $this->assertIsArray($decoded);
+        $this->assertArrayHasKey('error', $decoded);
+
+        unset($_SERVER['HTTP_X_REQUESTED_WITH']);
     }
 
     #[Test]

--- a/tests/Unit/Middleware/WorkflowWriteMiddlewareTest.php
+++ b/tests/Unit/Middleware/WorkflowWriteMiddlewareTest.php
@@ -53,6 +53,7 @@ class WorkflowWriteMiddlewareTest extends TestCase
 
         $this->assertFalse($result);
         $this->assertSame('/app/home', $redirectedTo);
+        unset($_SERVER['HTTP_X_REQUESTED_WITH']);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- `WorkflowWriteMiddleware` and `AuthMiddleware` were redirecting ALL blocked requests — including AJAX/JSON calls — to an HTML page
- The JS `fetch()` followed the redirect, got back the full HTML shell, and `r.json()` threw `SyntaxError: Unexpected token '<'`
- This manifested as **\"Failed: Unexpected token '<'\"** when a user clicked Reject on a board review (or any other AJAX action protected by `workflow_write`)
- Fix: detect `X-Requested-With: XMLHttpRequest` or `Content-Type: application/json` and return a JSON 403/401 body; browser navigation still gets the original redirect

## Test plan

- [ ] `WorkflowWriteMiddlewareTest::viewerReceivesJsonForbiddenOnAjaxRequest` — blocked AJAX returns JSON `{"error":"..."}`, no redirect
- [ ] `AuthMiddlewareTest::unauthenticatedAjaxRequestReceivesJson401` — expired session on AJAX returns JSON `{"error":"..."}`, no redirect
- [ ] Existing redirect-path tests still pass (9/9 total)
- [ ] Manual: log in as a viewer, open board review, click Reject → should now see a proper error rather than a browser alert with DOCTYPE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AJAX/JSON requests now receive JSON error responses (401 for unauthenticated, 403 for insufficient permissions) with security headers and clear error messages instead of HTML redirects.
* **Tests**
  * Added unit tests covering AJAX/JSON detection and error responses for auth and permission failures.
* **Documentation**
  * Added a macOS (MAMP) local development setup guide.
* **UI**
  * Updated header control buttons/partials, removed a runtime review modal, and added Subresource Integrity attributes to external scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->