### PR TITLE
fix(ui): change superadmin background from pink to light green

### DIFF
--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -235,7 +235,7 @@ main.container {
 .superadmin-theme,
 .superadmin-theme .app-content,
 .superadmin-theme .app-main {
-    background: #fdf4ff;
+    background: #f0fdf4;
 }
 
 


### PR DESCRIPTION
## Summary
- Changes `.superadmin-theme` background from `#fdf4ff` (pink/lavender) to `#f0fdf4` (light green)
- One-line CSS change in `public/assets/css/app.css`

## Test plan
- [ ] Log in as a superadmin user and verify the app background is light green

🤖 Generated with [Claude Code](https://claude.com/claude-code)